### PR TITLE
Add IDE-friendly main entry point and sample data

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,17 @@ java -jar target/motor-reporting-1.0-SNAPSHOT-jar-with-dependencies.jar /path/to
 The PDF is created in the same directory as the input file. For CSV inputs simply point
 the command at the `.csv` file.
 
+### Running from an IDE
+
+If you prefer to run the application from your IDE, use the `com.example.motorreporting.MotorReportingMain`
+class. Supply the input file name (for example `quotes_sample.csv`) as the program argument and the
+application will resolve it relative to the bundled `source data` directory.
+
+### Sample data
+
+A sample CSV file is included at `source data/quotes_sample.csv` so you can generate a report without
+providing your own data.
+
 ## Output
 
 The PDF report includes:

--- a/source data/quotes_sample.csv
+++ b/source data/quotes_sample.csv
@@ -1,0 +1,5 @@
+QuoteRequestedOn,Status,ReferenceNumber,InsurancePurpose,ICName,ShoryMakeEn,ShoryModelEn,OverrideIsGccSpec,Age,LicenseIssueDate,BodyCategory,ChassisNumber,InsuranceType,ManufactureYear,RegistrationDate,QuotationNo,EstimatedValue,InsuranceExpiryDate,ErrorText
+2024-01-05 08:15,Success,REF-001,Personal,Alliance,MakeA,ModelX,true,32,2014-09-01,Sedan,CHS1234567890,TPL,2021,2021-02-01,QTN-0001,55000,2024-12-31,
+2024-01-07 10:42,Failed,REF-002,Business,Guardian,MakeB,ModelY,false,41,2009-04-18,SUV,CHS0987654321,Comprehensive,2019,2019-06-15,QTN-0002,78000,2024-11-30,Vehicle inspection required
+2024-01-09 13:20,Failed,REF-003,Personal,Alliance,MakeC,ModelZ,true,28,2016-01-05,Hatchback,CHS5678901234,TPL,2020,2020-03-20,QTN-0003,43000,2024-10-15,Invalid chassis number
+2024-01-11 16:05,Success,REF-004,Business,Guardian,MakeD,ModelQ,true,36,2012-07-11,Truck,CHS2345678901,Comprehensive,2018,2018-05-10,QTN-0004,90000,2025-01-10,

--- a/src/main/java/com/example/motorreporting/MotorReportingMain.java
+++ b/src/main/java/com/example/motorreporting/MotorReportingMain.java
@@ -1,0 +1,38 @@
+package com.example.motorreporting;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Objects;
+
+/**
+ * Convenience entry point for running the report generator from code.
+ */
+public final class MotorReportingMain {
+
+    private MotorReportingMain() {
+    }
+
+    public static void main(String[] args) {
+        if (args.length == 0) {
+            System.err.println("Usage: MotorReportingMain <input-file>");
+            System.err.println("Place the data file in the 'source data' directory or provide an absolute path.");
+            System.exit(1);
+            return;
+        }
+
+        try {
+            Path outputPath = run(args[0]);
+            System.out.println("Report generated at: " + outputPath.toAbsolutePath());
+        } catch (IOException ex) {
+            System.err.println("Failed to generate report: " + ex.getMessage());
+            ex.printStackTrace();
+            System.exit(2);
+        }
+    }
+
+    public static Path run(String fileName) throws IOException {
+        Objects.requireNonNull(fileName, "fileName");
+        Path inputPath = QuoteReportGenerator.resolveInputPath(fileName);
+        return QuoteReportGenerator.generateReport(inputPath);
+    }
+}


### PR DESCRIPTION
## Summary
- expose reusable methods on `QuoteReportGenerator` so the report flow can be triggered programmatically
- add `MotorReportingMain` entry point that accepts a file name when running inside an IDE
- bundle a sample CSV in the repository and document how to run the app without the terminal

## Testing
- `mvn -q -DskipTests package` *(fails: repository is offline in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d245f8923c8325bdff4c11d0604c6f