### PR TITLE
Update quote outcomes and split PDF report by coverage

### DIFF
--- a/src/main/java/com/example/motorreporting/ChartCreator.java
+++ b/src/main/java/com/example/motorreporting/ChartCreator.java
@@ -76,6 +76,32 @@ public final class ChartCreator {
         return chart;
     }
 
+    public static JFreeChart createFailureByYearBarChart(QuoteGroupStats stats) {
+        DefaultCategoryDataset dataset = new DefaultCategoryDataset();
+        Map<String, Long> failuresByYear = stats.getFailuresByManufactureYear();
+
+        if (failuresByYear.isEmpty()) {
+            dataset.addValue(0, stats.getGroupType().getShortLabel(), "No Data");
+        } else {
+            failuresByYear.forEach((year, count) ->
+                    dataset.addValue(count, stats.getGroupType().getShortLabel(), year));
+        }
+
+        String title = stats.getGroupType().getDisplayName() + " - Failures by Manufacture Year";
+        JFreeChart chart = ChartFactory.createBarChart(
+                title,
+                "Manufacture Year",
+                "Failed Quotes",
+                dataset,
+                PlotOrientation.VERTICAL,
+                false,
+                true,
+                false);
+        chart.setBackgroundPaint(Color.WHITE);
+        chart.getTitle().setFont(new Font("SansSerif", Font.BOLD, 14));
+        return chart;
+    }
+
     public static JFreeChart createKpiSummaryChart(QuoteStatistics statistics) {
         DefaultCategoryDataset dataset = new DefaultCategoryDataset();
         QuoteGroupStats tpl = statistics.getTplStats();

--- a/src/main/java/com/example/motorreporting/QuoteGroupStats.java
+++ b/src/main/java/com/example/motorreporting/QuoteGroupStats.java
@@ -18,6 +18,7 @@ public class QuoteGroupStats {
     private final long totalQuotes;
     private final long passCount;
     private final long failCount;
+    private final long skipCount;
     private final double failurePercentage;
     private final Map<String, Long> failureReasonCounts;
     private final Map<String, Long> failuresByManufactureYear;
@@ -27,6 +28,7 @@ public class QuoteGroupStats {
                            long totalQuotes,
                            long passCount,
                            long failCount,
+                           long skipCount,
                            double failurePercentage,
                            Map<String, Long> failureReasonCounts,
                            Map<String, Long> failuresByManufactureYear,
@@ -35,6 +37,7 @@ public class QuoteGroupStats {
         this.totalQuotes = totalQuotes;
         this.passCount = passCount;
         this.failCount = failCount;
+        this.skipCount = skipCount;
         this.failurePercentage = failurePercentage;
         this.failureReasonCounts = Collections.unmodifiableMap(new LinkedHashMap<>(failureReasonCounts));
         this.failuresByManufactureYear = Collections.unmodifiableMap(new LinkedHashMap<>(failuresByManufactureYear));
@@ -42,7 +45,7 @@ public class QuoteGroupStats {
     }
 
     public static QuoteGroupStats empty(GroupType groupType) {
-        return new QuoteGroupStats(groupType, 0, 0, 0, 0.0,
+        return new QuoteGroupStats(groupType, 0, 0, 0, 0, 0.0,
                 Collections.emptyMap(), Collections.emptyMap(), BigDecimal.ZERO);
     }
 
@@ -60,6 +63,10 @@ public class QuoteGroupStats {
 
     public long getFailCount() {
         return failCount;
+    }
+
+    public long getSkipCount() {
+        return skipCount;
     }
 
     public double getFailurePercentage() {

--- a/src/main/java/com/example/motorreporting/QuoteStatistics.java
+++ b/src/main/java/com/example/motorreporting/QuoteStatistics.java
@@ -41,12 +41,20 @@ public class QuoteStatistics {
         return tplStats.getFailCount() + comprehensiveStats.getFailCount();
     }
 
+    public long getOverallSkipCount() {
+        return tplStats.getSkipCount() + comprehensiveStats.getSkipCount();
+    }
+
+    public long getOverallProcessedQuotes() {
+        return getOverallPassCount() + getOverallFailCount();
+    }
+
     public double getOverallFailurePercentage() {
-        long total = getOverallTotalQuotes();
-        if (total == 0) {
+        long processed = getOverallProcessedQuotes();
+        if (processed == 0) {
             return 0.0;
         }
-        return (getOverallFailCount() * 100.0) / total;
+        return (getOverallFailCount() * 100.0) / processed;
     }
 
     public BigDecimal getOverallBlockedEstimatedValue() {


### PR DESCRIPTION
## Summary
- classify quote results using quote number and error text, exposing quote numbers on each record
- track skipped quotes in group and overall statistics so failure rates only consider processed quotes
- restructure the PDF so TPL and Comprehensive each get their own section with updated metrics and charts

## Testing
- mvn -q -DskipTests package *(fails: repository access blocked in container)*

------
https://chatgpt.com/codex/tasks/task_b_68d24b17abb88325a84d72b3d3915fb6