### PR TITLE
Add overall insurance summary to PDF report

### DIFF
--- a/src/main/java/com/example/motorreporting/ChartCreator.java
+++ b/src/main/java/com/example/motorreporting/ChartCreator.java
@@ -26,16 +26,20 @@ public final class ChartCreator {
     }
 
     public static JFreeChart createFailureReasonPieChart(QuoteGroupStats stats) {
+        String title = stats.getGroupType().getDisplayName() + " - Failure Reasons";
+        return createFailureReasonPieChart(title, stats.getFailureReasonCounts());
+    }
+
+    public static JFreeChart createFailureReasonPieChart(String title, Map<String, Long> failureReasons) {
         DefaultPieDataset<String> dataset = new DefaultPieDataset<>();
-        Map<String, Long> failureReasons = stats.getFailureReasonCounts();
-        if (failureReasons.isEmpty()) {
+        if (failureReasons == null || failureReasons.isEmpty()) {
             dataset.setValue("No Failures", 1);
         } else {
             failureReasons.forEach(dataset::setValue);
         }
 
         JFreeChart chart = ChartFactory.createPieChart(
-                stats.getGroupType().getDisplayName() + " - Failure Reasons",
+                title,
                 dataset,
                 true,
                 true,
@@ -77,17 +81,22 @@ public final class ChartCreator {
     }
 
     public static JFreeChart createFailureByYearBarChart(QuoteGroupStats stats) {
-        DefaultCategoryDataset dataset = new DefaultCategoryDataset();
-        Map<String, Long> failuresByYear = stats.getFailuresByManufactureYear();
+        String title = stats.getGroupType().getDisplayName() + " - Failures by Manufacture Year";
+        return createFailureByYearBarChart(title, stats.getGroupType().getShortLabel(),
+                stats.getFailuresByManufactureYear());
+    }
 
-        if (failuresByYear.isEmpty()) {
-            dataset.addValue(0, stats.getGroupType().getShortLabel(), "No Data");
+    public static JFreeChart createFailureByYearBarChart(String title, String seriesLabel,
+                                                         Map<String, Long> failuresByYear) {
+        DefaultCategoryDataset dataset = new DefaultCategoryDataset();
+
+        if (failuresByYear == null || failuresByYear.isEmpty()) {
+            dataset.addValue(0, seriesLabel, "No Data");
         } else {
             failuresByYear.forEach((year, count) ->
-                    dataset.addValue(count, stats.getGroupType().getShortLabel(), year));
+                    dataset.addValue(count, seriesLabel, year));
         }
 
-        String title = stats.getGroupType().getDisplayName() + " - Failures by Manufacture Year";
         JFreeChart chart = ChartFactory.createBarChart(
                 title,
                 "Manufacture Year",

--- a/src/main/java/com/example/motorreporting/QuoteStatistics.java
+++ b/src/main/java/com/example/motorreporting/QuoteStatistics.java
@@ -2,6 +2,7 @@ package com.example.motorreporting;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -81,5 +82,26 @@ public class QuoteStatistics {
         return getCombinedFailureReasons().entrySet().stream()
                 .limit(limit)
                 .collect(Collectors.toList());
+    }
+
+    public Map<String, Long> getCombinedFailuresByManufactureYear() {
+        Map<String, Long> combined = new LinkedHashMap<>();
+        tplStats.getFailuresByManufactureYear().forEach((year, count) ->
+                combined.merge(year, count, Long::sum));
+        comprehensiveStats.getFailuresByManufactureYear().forEach((year, count) ->
+                combined.merge(year, count, Long::sum));
+
+        return combined.entrySet().stream()
+                .sorted(Comparator.comparingInt(entry -> yearOrderKey(entry.getKey())))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue,
+                        (a, b) -> a, LinkedHashMap::new));
+    }
+
+    private static int yearOrderKey(String label) {
+        try {
+            return Integer.parseInt(label);
+        } catch (NumberFormatException ex) {
+            return Integer.MAX_VALUE;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- aggregate combined failure totals in the statistics model to support cross-insurance reporting
- extend chart helpers so they can render aggregated datasets
- add an overall summary section to the generated PDF with combined metrics, breakdowns, and KPI comparisons

## Testing
- mvn -q -DskipTests package *(fails: unable to download maven-resources-plugin because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68d24f83c3f48325b68197e0c98a04b3