### PR TITLE
Replace records with static classes for report data

### DIFF
--- a/src/main/java/com/example/motorreporting/HtmlReportGenerator.java
+++ b/src/main/java/com/example/motorreporting/HtmlReportGenerator.java
@@ -805,9 +805,69 @@ public class HtmlReportGenerator {
         return PERCENT_FORMAT.format(value) + "%";
     }
 
-    private record ChartData(String canvasId, String labelsJson, String valuesJson, String colorsJson) {
+    private static final class ChartData {
+        private final String canvasId;
+        private final String labelsJson;
+        private final String valuesJson;
+        private final String colorsJson;
+
+        private ChartData(String canvasId, String labelsJson, String valuesJson, String colorsJson) {
+            this.canvasId = canvasId;
+            this.labelsJson = labelsJson;
+            this.valuesJson = valuesJson;
+            this.colorsJson = colorsJson;
+        }
+
+        private String canvasId() {
+            return canvasId;
+        }
+
+        private String labelsJson() {
+            return labelsJson;
+        }
+
+        private String valuesJson() {
+            return valuesJson;
+        }
+
+        private String colorsJson() {
+            return colorsJson;
+        }
     }
 
-    private record TrendData(List<String> labels, String labelsJson, String totalJson, String successJson, String failureJson) {
+    private static final class TrendData {
+        private final List<String> labels;
+        private final String labelsJson;
+        private final String totalJson;
+        private final String successJson;
+        private final String failureJson;
+
+        private TrendData(List<String> labels, String labelsJson, String totalJson, String successJson, String failureJson) {
+            this.labels = labels;
+            this.labelsJson = labelsJson;
+            this.totalJson = totalJson;
+            this.successJson = successJson;
+            this.failureJson = failureJson;
+        }
+
+        private List<String> labels() {
+            return labels;
+        }
+
+        private String labelsJson() {
+            return labelsJson;
+        }
+
+        private String totalJson() {
+            return totalJson;
+        }
+
+        private String successJson() {
+            return successJson;
+        }
+
+        private String failureJson() {
+            return failureJson;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- replace the HtmlReportGenerator ChartData record with a static final class preserving existing accessors
- convert TrendData record to a static final class while maintaining the same constructor parameters and methods

## Testing
- mvn -q package *(fails: plugin download blocked by network policy)*

------
https://chatgpt.com/codex/tasks/task_b_68d253d0b7d88325a39d70f6cb3b7d5b