### PR TITLE
Fix lambda-captured lists for chart data generation

### DIFF
--- a/src/main/java/com/example/motorreporting/HtmlReportGenerator.java
+++ b/src/main/java/com/example/motorreporting/HtmlReportGenerator.java
@@ -575,8 +575,8 @@ public class HtmlReportGenerator {
             values.add(count);
         });
         if (labels.isEmpty()) {
-            labels = List.of("No Failures Recorded");
-            values = List.of(1L);
+            labels.add("No Failures Recorded");
+            values.add(1L);
         }
         List<String> colors = createPalette(labels.size());
         String canvasId = stats.getGroupType() == GroupType.TPL ? "tplFailureReasonsChart" : "compFailureReasonsChart";
@@ -591,8 +591,8 @@ public class HtmlReportGenerator {
             values.add(count);
         });
         if (labels.isEmpty()) {
-            labels = List.of("No Data");
-            values = List.of(0L);
+            labels.add("No Data");
+            values.add(0L);
         }
         List<String> colors = Collections.nCopies(labels.size(), stats.getGroupType() == GroupType.TPL ? "rgba(13, 110, 253, 0.85)" : "rgba(220, 53, 69, 0.85)");
         String canvasId = stats.getGroupType() == GroupType.TPL ? "tplFailureByYearChart" : "compFailureByYearChart";


### PR DESCRIPTION
## Summary
- keep failure reason and year chart data lists mutable instead of reassigning them
- avoid reassigning lambda-captured variables that caused compilation to fail

## Testing
- mvn -q -DskipTests compile *(fails: unable to download dependencies because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68d254c58c1c8325affe05e7cb84b4be