### PR TITLE
Add Shory branding to generated reports

### DIFF
--- a/src/main/java/com/example/motorreporting/HtmlReportGenerator.java
+++ b/src/main/java/com/example/motorreporting/HtmlReportGenerator.java
@@ -15,6 +15,7 @@ import java.util.Objects;
  */
 public class HtmlReportGenerator {
 
+    private static final String LOGO_URL = "https://www.shory.com/imgs/master/logo.svg";
     private static final DecimalFormat INTEGER_FORMAT;
 
     static {
@@ -69,6 +70,12 @@ public class HtmlReportGenerator {
         html.append("        .page-header {\n");
         html.append("            text-align: center;\n");
         html.append("            margin-bottom: 3rem;\n");
+        html.append("        }\n");
+        html.append("        .company-logo {\n");
+        html.append("            width: clamp(140px, 18vw, 180px);\n");
+        html.append("            height: auto;\n");
+        html.append("            margin: 0 auto 1.75rem;\n");
+        html.append("            display: block;\n");
         html.append("        }\n");
         html.append("        .page-header h1 {\n");
         html.append("            margin: 0 0 0.75rem;\n");
@@ -157,6 +164,9 @@ public class HtmlReportGenerator {
         html.append("<body>\n");
         html.append("<main>\n");
         html.append("  <div class=\"page-header\">\n");
+        html.append("    <img src=\"")
+                .append(escapeHtml(LOGO_URL))
+                .append("\" alt=\"Shory company logo\" class=\"company-logo\" loading=\"lazy\">\n");
         html.append("    <h1>Motor Quote Summary</h1>\n");
         html.append("    <p>Overview of quote requests with pass and fail counts for each insurance type.</p>\n");
         html.append("  </div>\n");

--- a/src/main/java/com/example/motorreporting/PdfReportGenerator.java
+++ b/src/main/java/com/example/motorreporting/PdfReportGenerator.java
@@ -1,5 +1,6 @@
 package com.example.motorreporting;
 
+import com.lowagie.text.BadElementException;
 import com.lowagie.text.Chunk;
 import com.lowagie.text.Document;
 import com.lowagie.text.DocumentException;
@@ -18,6 +19,7 @@ import java.awt.Color;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.text.DecimalFormat;
@@ -37,6 +39,7 @@ public class PdfReportGenerator {
     private static final DecimalFormat INTEGER_FORMAT = new DecimalFormat("#,##0");
     private static final DecimalFormat PERCENT_FORMAT = new DecimalFormat("0.0'%'");
     private static final DecimalFormat CURRENCY_FORMAT = new DecimalFormat("#,##0.00");
+    private static final String LOGO_URL = "https://www.shory.com/imgs/master/logo.svg";
 
     public void generate(Path outputPath, QuoteStatistics statistics) throws IOException {
         Document document = new Document(PageSize.A4, 36, 36, 54, 36);
@@ -71,6 +74,7 @@ public class PdfReportGenerator {
     }
 
     private void addTitlePage(Document document) throws DocumentException {
+        addLogo(document);
         Paragraph title = new Paragraph("Quote Generation Report", TITLE_FONT);
         title.setAlignment(Element.ALIGN_CENTER);
         document.add(title);
@@ -78,6 +82,20 @@ public class PdfReportGenerator {
         Paragraph date = new Paragraph("Report Date: " + LocalDate.now(), NORMAL_FONT);
         date.setAlignment(Element.ALIGN_CENTER);
         document.add(date);
+        addSpacing(document);
+    }
+
+    private void addLogo(Document document) throws DocumentException {
+        try {
+            com.lowagie.text.Image logo = com.lowagie.text.Image.getInstance(new URL(LOGO_URL));
+            logo.scaleToFit(180, 70);
+            logo.setAlignment(Element.ALIGN_CENTER);
+            document.add(logo);
+        } catch (BadElementException | IOException ex) {
+            Paragraph fallback = new Paragraph("Shory", SUBTITLE_FONT);
+            fallback.setAlignment(Element.ALIGN_CENTER);
+            document.add(fallback);
+        }
         addSpacing(document);
     }
 


### PR DESCRIPTION
## Summary
- display the Shory logo at the top of the generated HTML report alongside the existing summary content
- attempt to load the Shory logo on the PDF title page with a graceful text fallback when the image cannot be retrieved

## Testing
- mvn -q -DskipTests package *(fails: unable to reach Maven Central from the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d258f968e08325a6ccf3c48f17cced