### PR TITLE
Add sequential clean data, HTML, and PDF report generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,14 @@ mvn clean package
 java -jar target/motor-reporting-1.0-SNAPSHOT-jar-with-dependencies.jar /path/to/quotes.xlsx
 ```
 
-The HTML report is created in the same directory as the input file. For CSV inputs simply point
-the command at the `.csv` file.
+The command now executes three sequential steps:
+
+1. Cleans the dataset and writes `quote_generation_cleaned.csv` beside the source file.
+2. Builds the HTML dashboard `quote_generation_report.html` in the same directory.
+3. Generates the PDF summary `quote_generation_report.pdf` alongside the other outputs.
+
+For CSV inputs simply point the command at the `.csv` file and the same trio of artifacts will be
+created next to it.
 
 ### Running from an IDE
 

--- a/src/main/java/com/example/motorreporting/MotorReportingMain.java
+++ b/src/main/java/com/example/motorreporting/MotorReportingMain.java
@@ -21,8 +21,13 @@ public final class MotorReportingMain {
         }
 
         try {
-            Path outputPath = run(args[0]);
-            System.out.println("Report generated at: " + outputPath.toAbsolutePath());
+            ReportGenerationResult result = run(args[0]);
+            System.out.println("Cleaned data file created at: "
+                    + result.getCleanedDataPath().toAbsolutePath());
+            System.out.println("HTML report generated at: "
+                    + result.getHtmlReportPath().toAbsolutePath());
+            System.out.println("PDF report generated at: "
+                    + result.getPdfReportPath().toAbsolutePath());
         } catch (IOException ex) {
             System.err.println("Failed to generate report: " + ex.getMessage());
             ex.printStackTrace();
@@ -30,7 +35,7 @@ public final class MotorReportingMain {
         }
     }
 
-    public static Path run(String fileName) throws IOException {
+    public static ReportGenerationResult run(String fileName) throws IOException {
         Objects.requireNonNull(fileName, "fileName");
         Path inputPath = QuoteReportGenerator.resolveInputPath(fileName);
         return QuoteReportGenerator.generateReport(inputPath);

--- a/src/main/java/com/example/motorreporting/QuoteDataCleaner.java
+++ b/src/main/java/com/example/motorreporting/QuoteDataCleaner.java
@@ -1,0 +1,95 @@
+package com.example.motorreporting;
+
+import com.opencsv.CSVWriter;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Writes a cleaned representation of the input dataset.
+ */
+public final class QuoteDataCleaner {
+
+    private static final List<String> DEFAULT_COLUMN_ORDER = List.of(
+            "QuoteRequestedOn",
+            "Status",
+            "ReferenceNumber",
+            "InsurancePurpose",
+            "ICName",
+            "ShoryMakeEn",
+            "ShoryModelEn",
+            "OverrideIsGccSpec",
+            "Age",
+            "LicenseIssueDate",
+            "BodyCategory",
+            "ChassisNumber",
+            "InsuranceType",
+            "ManufactureYear",
+            "RegistrationDate",
+            "QuotationNo",
+            "EstimatedValue",
+            "InsuranceExpiryDate",
+            "ErrorText"
+    );
+
+    private QuoteDataCleaner() {
+    }
+
+    public static Path writeCleanFile(Path outputDirectory, List<QuoteRecord> records) throws IOException {
+        Objects.requireNonNull(outputDirectory, "outputDirectory");
+        Objects.requireNonNull(records, "records");
+
+        Path resolvedDirectory = outputDirectory.toAbsolutePath();
+        Files.createDirectories(resolvedDirectory);
+
+        Path cleanedFile = resolvedDirectory.resolve("quote_generation_cleaned.csv");
+        List<String> headers = determineHeaders(records);
+
+        try (Writer writer = Files.newBufferedWriter(cleanedFile, StandardCharsets.UTF_8);
+             CSVWriter csvWriter = new CSVWriter(writer,
+                     CSVWriter.DEFAULT_SEPARATOR,
+                     CSVWriter.DEFAULT_QUOTE_CHARACTER,
+                     CSVWriter.DEFAULT_ESCAPE_CHARACTER,
+                     CSVWriter.DEFAULT_LINE_END)) {
+            csvWriter.writeNext(headers.toArray(new String[0]), false);
+            for (QuoteRecord record : records) {
+                String[] row = new String[headers.size()];
+                Map<String, String> values = record.getRawValues();
+                for (int i = 0; i < headers.size(); i++) {
+                    row[i] = findValue(values, headers.get(i));
+                }
+                csvWriter.writeNext(row, false);
+            }
+        }
+
+        return cleanedFile;
+    }
+
+    private static List<String> determineHeaders(List<QuoteRecord> records) {
+        Set<String> headers = new LinkedHashSet<>(DEFAULT_COLUMN_ORDER);
+        for (QuoteRecord record : records) {
+            headers.addAll(record.getRawValues().keySet());
+        }
+        return new ArrayList<>(headers);
+    }
+
+    private static String findValue(Map<String, String> values, String header) {
+        for (Map.Entry<String, String> entry : values.entrySet()) {
+            String key = entry.getKey();
+            if (key != null && key.equalsIgnoreCase(header)) {
+                String value = entry.getValue();
+                return value == null ? "" : value;
+            }
+        }
+        return "";
+    }
+}

--- a/src/main/java/com/example/motorreporting/ReportGenerationResult.java
+++ b/src/main/java/com/example/motorreporting/ReportGenerationResult.java
@@ -1,0 +1,32 @@
+package com.example.motorreporting;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+/**
+ * Holds references to all generated artifacts for a report run.
+ */
+public final class ReportGenerationResult {
+
+    private final Path cleanedDataPath;
+    private final Path htmlReportPath;
+    private final Path pdfReportPath;
+
+    public ReportGenerationResult(Path cleanedDataPath, Path htmlReportPath, Path pdfReportPath) {
+        this.cleanedDataPath = Objects.requireNonNull(cleanedDataPath, "cleanedDataPath");
+        this.htmlReportPath = Objects.requireNonNull(htmlReportPath, "htmlReportPath");
+        this.pdfReportPath = Objects.requireNonNull(pdfReportPath, "pdfReportPath");
+    }
+
+    public Path getCleanedDataPath() {
+        return cleanedDataPath;
+    }
+
+    public Path getHtmlReportPath() {
+        return htmlReportPath;
+    }
+
+    public Path getPdfReportPath() {
+        return pdfReportPath;
+    }
+}


### PR DESCRIPTION
## Summary
- add a QuoteDataCleaner utility and ReportGenerationResult to manage generated artifacts
- run the reporting pipeline sequentially to emit cleaned data, HTML, and PDF outputs
- update the command-line entry points and README to describe the new workflow

## Testing
- mvn -q -DskipTests package *(fails: unable to download maven-resources-plugin because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68d26cfb37f88325be80c708b0b651ac