### PR TITLE
Normalize date columns in CSV processing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,12 @@
             <artifactId>slf4j-simple</artifactId>
             <version>2.0.12</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -71,6 +77,14 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.3</version>
+                <configuration>
+                    <useModulePath>false</useModulePath>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/com/example/motorreporting/DateNormalizer.java
+++ b/src/main/java/com/example/motorreporting/DateNormalizer.java
@@ -1,0 +1,230 @@
+package com.example.motorreporting;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
+import java.time.format.SignStyle;
+import java.time.temporal.ChronoField;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+/**
+ * Normalizes date-like values into a consistent format.
+ */
+final class DateNormalizer {
+
+    private static final Pattern TIME_ONLY_PATTERN = Pattern.compile("^\\d{1,2}:\\d{2}(:\\d{2})?(\\.\\d+)?$", Pattern.CASE_INSENSITIVE);
+    private static final Pattern EXCEL_SERIAL_PATTERN = Pattern.compile("^-?\\d+(\\.\\d+)?$");
+    private static final DateTimeFormatter OUTPUT_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+            .withLocale(Locale.ROOT);
+    private static final LocalDate EXCEL_EPOCH = LocalDate.of(1899, 12, 31);
+    private static final double SECONDS_PER_DAY = 24d * 60d * 60d;
+
+    private static final List<DateTimeFormatter> DATE_FORMATTERS = buildDateFormatters();
+    private static final List<DateTimeFormatter> DATE_TIME_FORMATTERS = buildDateTimeFormatters();
+
+    private DateNormalizer() {
+    }
+
+    static boolean isDateColumn(String header) {
+        return header != null && header.toLowerCase(Locale.ROOT).contains("date");
+    }
+
+    static String normalize(String value) {
+        if (value == null) {
+            return "";
+        }
+        String trimmed = value.trim();
+        if (trimmed.isEmpty()) {
+            return "";
+        }
+        if (TIME_ONLY_PATTERN.matcher(trimmed).matches()) {
+            return "";
+        }
+
+        LocalDateTime dateTime = parseDateTime(trimmed);
+        if (dateTime != null) {
+            return OUTPUT_FORMAT.format(dateTime);
+        }
+
+        LocalDate date = parseDate(trimmed);
+        if (date != null) {
+            return OUTPUT_FORMAT.format(date.atStartOfDay());
+        }
+
+        dateTime = parseExcelSerial(trimmed);
+        if (dateTime != null) {
+            return OUTPUT_FORMAT.format(dateTime);
+        }
+
+        return "";
+    }
+
+    private static LocalDateTime parseDateTime(String value) {
+        try {
+            Instant instant = Instant.parse(adjustIsoString(value));
+            return LocalDateTime.ofInstant(instant, ZoneOffset.UTC);
+        } catch (DateTimeParseException ex) {
+            // ignore
+        }
+
+        try {
+            return LocalDateTime.ofInstant(java.time.OffsetDateTime.parse(value).toInstant(), ZoneOffset.UTC);
+        } catch (DateTimeParseException ex) {
+            // ignore
+        }
+
+        try {
+            return LocalDateTime.ofInstant(java.time.ZonedDateTime.parse(value).toInstant(), ZoneOffset.UTC);
+        } catch (DateTimeParseException ex) {
+            // ignore
+        }
+
+        for (DateTimeFormatter formatter : DATE_TIME_FORMATTERS) {
+            try {
+                return LocalDateTime.parse(value, formatter);
+            } catch (DateTimeParseException ex) {
+                // try next
+            }
+        }
+        return null;
+    }
+
+    private static String adjustIsoString(String value) {
+        if (value.indexOf(' ') > 0 && value.endsWith("Z")) {
+            return value.replace(' ', 'T');
+        }
+        return value;
+    }
+
+    private static LocalDate parseDate(String value) {
+        for (DateTimeFormatter formatter : DATE_FORMATTERS) {
+            try {
+                return LocalDate.parse(value, formatter);
+            } catch (DateTimeParseException ex) {
+                // try next
+            }
+        }
+        return null;
+    }
+
+    private static LocalDateTime parseExcelSerial(String value) {
+        if (!EXCEL_SERIAL_PATTERN.matcher(value).matches()) {
+            return null;
+        }
+        double numericValue;
+        try {
+            numericValue = Double.parseDouble(value);
+        } catch (NumberFormatException ex) {
+            return null;
+        }
+        if (!Double.isFinite(numericValue) || numericValue < 1) {
+            return null;
+        }
+        long wholeDays = (long) Math.floor(numericValue);
+        double fraction = numericValue - wholeDays;
+        if (wholeDays >= 60) {
+            wholeDays -= 1;
+        }
+        LocalDate date = EXCEL_EPOCH.plusDays(wholeDays);
+        long seconds = Math.round(fraction * SECONDS_PER_DAY);
+        return date.atStartOfDay().plusSeconds(seconds);
+    }
+
+    private static List<DateTimeFormatter> buildDateFormatters() {
+        List<DateTimeFormatter> formatters = new ArrayList<>();
+        formatters.add(DateTimeFormatter.ISO_LOCAL_DATE);
+        formatters.add(DateTimeFormatter.BASIC_ISO_DATE);
+        String[] patterns = {
+                "uuuu-M-d",
+                "uuuu/MM/dd",
+                "uuuu/M/d",
+                "uuuu.MM.dd",
+                "uuuu.M.d",
+                "d/M/uuuu",
+                "dd/MM/uuuu",
+                "M/d/uuuu",
+                "MM/dd/uuuu",
+                "d-M-uuuu",
+                "dd-MM-uuuu",
+                "M-d-uuuu",
+                "MM-dd-uuuu",
+                "d.M.uuuu",
+                "dd.MM.uuuu",
+                "M.d.uuuu",
+                "MM.dd.uuuu"
+        };
+        for (String pattern : patterns) {
+            formatters.add(createFormatter(pattern));
+        }
+        return formatters;
+    }
+
+    private static List<DateTimeFormatter> buildDateTimeFormatters() {
+        List<DateTimeFormatter> formatters = new ArrayList<>();
+        formatters.add(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+        formatters.add(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+        formatters.add(DateTimeFormatter.ISO_ZONED_DATE_TIME);
+        String[] datePatterns = {
+                "uuuu-MM-dd",
+                "uuuu-M-d",
+                "uuuu/MM/dd",
+                "uuuu/M/d",
+                "uuuu.MM.dd",
+                "uuuu.M.d",
+                "dd/MM/uuuu",
+                "d/M/uuuu",
+                "MM/dd/uuuu",
+                "M/d/uuuu",
+                "dd-MM-uuuu",
+                "d-M-uuuu",
+                "MM-dd-uuuu",
+                "M-d-uuuu",
+                "dd.MM.uuuu",
+                "d.M.uuuu",
+                "MM.dd.uuuu",
+                "M.d.uuuu"
+        };
+        char[] separators = {' ', 'T'};
+        for (String pattern : datePatterns) {
+            for (char separator : separators) {
+                formatters.add(buildDateTimeFormatter(pattern, separator));
+            }
+        }
+        return formatters;
+    }
+
+    private static DateTimeFormatter createFormatter(String pattern) {
+        return new DateTimeFormatterBuilder()
+                .parseCaseInsensitive()
+                .appendPattern(pattern)
+                .toFormatter(Locale.ROOT)
+                .withResolverStyle(ResolverStyle.SMART);
+    }
+
+    private static DateTimeFormatter buildDateTimeFormatter(String datePattern, char separator) {
+        DateTimeFormatterBuilder builder = new DateTimeFormatterBuilder()
+                .parseCaseInsensitive()
+                .appendPattern(datePattern)
+                .appendLiteral(separator)
+                .appendValue(ChronoField.HOUR_OF_DAY, 1, 2, SignStyle.NOT_NEGATIVE)
+                .appendLiteral(':')
+                .appendValue(ChronoField.MINUTE_OF_HOUR, 2);
+        builder.optionalStart()
+                .appendLiteral(':')
+                .appendValue(ChronoField.SECOND_OF_MINUTE, 2);
+        builder.optionalStart()
+                .appendLiteral('.')
+                .appendFraction(ChronoField.NANO_OF_SECOND, 1, 9, false);
+        builder.optionalEnd();
+        builder.optionalEnd();
+        return builder.toFormatter(Locale.ROOT).withResolverStyle(ResolverStyle.SMART);
+    }
+}

--- a/src/main/java/com/example/motorreporting/QuoteDataCleaner.java
+++ b/src/main/java/com/example/motorreporting/QuoteDataCleaner.java
@@ -87,6 +87,9 @@ public final class QuoteDataCleaner {
             String key = entry.getKey();
             if (key != null && key.equalsIgnoreCase(header)) {
                 String value = entry.getValue();
+                if (DateNormalizer.isDateColumn(header)) {
+                    return DateNormalizer.normalize(value);
+                }
                 return value == null ? "" : value;
             }
         }

--- a/src/main/java/com/example/motorreporting/QuoteDataLoader.java
+++ b/src/main/java/com/example/motorreporting/QuoteDataLoader.java
@@ -18,9 +18,9 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Locale;
 
 /**
  * Loads quote data from either Excel or CSV files.
@@ -120,7 +120,8 @@ public final class QuoteDataLoader {
             Map<Integer, String> headerIndex = new HashMap<>();
             for (int i = 0; i < headers.length; i++) {
                 if (headers[i] != null && !headers[i].trim().isEmpty()) {
-                    headerIndex.put(i, headers[i].trim());
+                    String header = headers[i].trim();
+                    headerIndex.put(i, header);
                 }
             }
 
@@ -134,6 +135,9 @@ public final class QuoteDataLoader {
                     int index = entry.getKey();
                     String header = entry.getValue();
                     String value = index < row.length && row[index] != null ? row[index].trim() : "";
+                    if (DateNormalizer.isDateColumn(header)) {
+                        value = DateNormalizer.normalize(value);
+                    }
                     values.put(header, value);
                 }
                 records.add(QuoteRecord.fromValues(values));

--- a/src/test/java/com/example/motorreporting/QuoteDataCleanerDateNormalizationTest.java
+++ b/src/test/java/com/example/motorreporting/QuoteDataCleanerDateNormalizationTest.java
@@ -1,0 +1,55 @@
+package com.example.motorreporting;
+
+import com.opencsv.CSVReader;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class QuoteDataCleanerDateNormalizationTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void writesDateColumnsInConsistentFormat() throws IOException {
+        Map<String, String> values = new HashMap<>();
+        values.put("Start_Date", "03-21-2024");
+        values.put("CreatedDate", "2024/03/22 5:45");
+        values.put("Name", "Charlie");
+        values.put("Status", "");
+        values.put("QuotationNo", "");
+        values.put("ErrorText", "Null");
+
+        QuoteRecord record = QuoteRecord.fromValues(values);
+
+        Path cleanedFile = QuoteDataCleaner.writeCleanFile(tempDir, List.of(record));
+
+        try (Reader reader = Files.newBufferedReader(cleanedFile, StandardCharsets.UTF_8);
+             CSVReader csvReader = new CSVReader(reader)) {
+            String[] header = csvReader.readNext();
+            String[] row = csvReader.readNext();
+            assertNotNull(header);
+            assertNotNull(row);
+
+            Map<String, Integer> indexByHeader = new HashMap<>();
+            for (int i = 0; i < header.length; i++) {
+                indexByHeader.put(header[i], i);
+            }
+
+            assertEquals("2024-03-21 00:00:00", row[indexByHeader.get("Start_Date")]);
+            assertEquals("2024-03-22 05:45:00", row[indexByHeader.get("CreatedDate")]);
+            assertEquals("Charlie", row[indexByHeader.get("Name")]);
+        }
+    }
+}

--- a/src/test/java/com/example/motorreporting/QuoteDataLoaderCsvDateNormalizationTest.java
+++ b/src/test/java/com/example/motorreporting/QuoteDataLoaderCsvDateNormalizationTest.java
@@ -1,0 +1,48 @@
+package com.example.motorreporting;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class QuoteDataLoaderCsvDateNormalizationTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void normalizesDateColumnsWithoutTouchingOthers() throws IOException {
+        Path csvFile = tempDir.resolve("quotes.csv");
+        List<String> lines = List.of(
+                "Name,CreatedDate,Start_Date,Amount",
+                "Alice,2023-03-01T14:30:00Z,15/11/2023,100",
+                "Bob,00:00.0,45205,200"
+        );
+        Files.write(csvFile, lines, StandardCharsets.UTF_8);
+
+        List<QuoteRecord> records = QuoteDataLoader.load(csvFile);
+        assertEquals(2, records.size());
+
+        Map<String, String> firstRow = records.get(0).getRawValues();
+        assertEquals("2023-03-01 14:30:00", firstRow.get("CreatedDate"));
+        assertEquals("2023-11-15 00:00:00", firstRow.get("Start_Date"));
+        assertEquals("Alice", firstRow.get("Name"));
+        assertEquals("100", firstRow.get("Amount"));
+
+        Map<String, String> secondRow = records.get(1).getRawValues();
+        assertEquals("", secondRow.get("CreatedDate"));
+        assertEquals("2023-10-06 00:00:00", secondRow.get("Start_Date"));
+        assertEquals("Bob", secondRow.get("Name"));
+        assertEquals("200", secondRow.get("Amount"));
+
+        assertTrue(secondRow.containsKey("Status"));
+    }
+}


### PR DESCRIPTION
## Summary
- add a `DateNormalizer` utility to parse and normalize CSV date values, including Excel serial numbers and time-only values
- update the CSV loader and cleaner so that only columns with "date" in the header are automatically normalized and exported in a consistent format
- add unit tests covering CSV ingestion and cleaned export paths to ensure date columns are corrected while non-date columns remain unchanged

## Testing
- mvn test *(fails: network unreachable while downloading Maven plugin)*

------
https://chatgpt.com/codex/tasks/task_b_68d26fbb22d08325a60bb798f267ddf6