### PR TITLE
Fix test exception handling

### DIFF
--- a/src/test/java/com/example/motorreporting/QuoteDataCleanerDateNormalizationTest.java
+++ b/src/test/java/com/example/motorreporting/QuoteDataCleanerDateNormalizationTest.java
@@ -1,6 +1,7 @@
 package com.example.motorreporting;
 
 import com.opencsv.CSVReader;
+import com.opencsv.exceptions.CsvValidationException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -22,7 +23,7 @@ class QuoteDataCleanerDateNormalizationTest {
     Path tempDir;
 
     @Test
-    void writesDateColumnsInConsistentFormat() throws IOException {
+    void writesDateColumnsInConsistentFormat() throws IOException, CsvValidationException {
         Map<String, String> values = new HashMap<>();
         values.put("Start_Date", "03-21-2024");
         values.put("CreatedDate", "2024/03/22 5:45");


### PR DESCRIPTION
## Summary
- update the date normalization test to import CsvValidationException
- declare CsvValidationException in the test method signature to resolve the compilation error

## Testing
- mvn test *(fails: network unreachable while resolving maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_b_68d274708aac8325b0aa697780f1c6f2