### PR TITLE
Align quote outcomes with status column

### DIFF
--- a/src/test/java/com/example/motorreporting/QuoteStatisticsCalculatorStatusTest.java
+++ b/src/test/java/com/example/motorreporting/QuoteStatisticsCalculatorStatusTest.java
@@ -1,0 +1,45 @@
+package com.example.motorreporting;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class QuoteStatisticsCalculatorStatusTest {
+
+    @Test
+    void successAndFailureCountsFollowStatusColumn() {
+        QuoteRecord successRecord = QuoteRecord.fromValues(Map.of(
+                "InsuranceType", "Third Party",
+                "Status", "Success",
+                "ErrorText", "Vehicle inspection required",
+                "QuotationNo", ""
+        ));
+
+        QuoteRecord failureRecord = QuoteRecord.fromValues(Map.of(
+                "InsuranceType", "Comprehensive",
+                "Status", "Failed",
+                "ErrorText", "",
+                "QuotationNo", "QTN-0042"
+        ));
+
+        QuoteRecord skippedRecord = QuoteRecord.fromValues(Map.of(
+                "InsuranceType", "Third Party",
+                "Status", "Skipped",
+                "ErrorText", "",
+                "QuotationNo", "QTN-0099"
+        ));
+
+        QuoteStatistics statistics = QuoteStatisticsCalculator.calculate(List.of(
+                successRecord,
+                failureRecord,
+                skippedRecord
+        ));
+
+        assertEquals(1, statistics.getOverallPassCount());
+        assertEquals(1, statistics.getOverallFailCount());
+        assertEquals(1, statistics.getOverallSkipCount());
+    }
+}


### PR DESCRIPTION
## Summary
- derive quote outcomes primarily from the provided status column with a fallback to existing error/quotation heuristics
- standardize status values and update success/failure/skip detection to rely on the derived outcome
- add a regression test that ensures statistics honour the status column values

## Testing
- mvn -q test *(fails: unable to resolve maven-resources-plugin because the build environment cannot access Maven Central)*

------
https://chatgpt.com/codex/tasks/task_b_68d276b1e07c8325b544dace1b3665fd