### PR TITLE
Fix HTML header date range detection

### DIFF
--- a/src/main/java/com/example/motorreporting/HtmlReportGenerator.java
+++ b/src/main/java/com/example/motorreporting/HtmlReportGenerator.java
@@ -30,6 +30,8 @@ public class HtmlReportGenerator {
     };
     private static final DateTimeFormatter HEADER_DATE_FORMAT =
             DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.US);
+    private static final String QUOTE_REQUESTED_ON_KEY_NORMALIZED =
+            normalizeHeaderKey("QuoteRequestedOn");
 
     static {
         DecimalFormatSymbols symbols = DecimalFormatSymbols.getInstance(Locale.US);
@@ -247,7 +249,7 @@ public class HtmlReportGenerator {
     private Optional<LocalDateTime> extractQuoteRequestedOn(QuoteRecord record) {
         for (Map.Entry<String, String> entry : record.getRawValues().entrySet()) {
             String key = entry.getKey();
-            if (key != null && key.equalsIgnoreCase("QuoteRequestedOn")) {
+            if (isQuoteRequestedOnKey(key)) {
                 String value = entry.getValue();
                 if (value == null) {
                     return Optional.empty();
@@ -256,6 +258,15 @@ public class HtmlReportGenerator {
             }
         }
         return Optional.empty();
+    }
+
+    private static boolean isQuoteRequestedOnKey(String key) {
+        if (key == null || key.isEmpty()) {
+            return false;
+        }
+        String normalized = normalizeHeaderKey(key);
+        return normalized.equals(QUOTE_REQUESTED_ON_KEY_NORMALIZED)
+                || normalized.contains(QUOTE_REQUESTED_ON_KEY_NORMALIZED);
     }
 
     private Optional<LocalDateTime> parseQuoteRequestedOn(String value) {
@@ -283,6 +294,20 @@ public class HtmlReportGenerator {
 
     private String formatDateForHeader(LocalDateTime dateTime) {
         return dateTime.toLocalDate().format(HEADER_DATE_FORMAT);
+    }
+
+    private static String normalizeHeaderKey(String key) {
+        if (key == null) {
+            return "";
+        }
+        StringBuilder normalized = new StringBuilder(key.length());
+        for (int i = 0; i < key.length(); i++) {
+            char ch = key.charAt(i);
+            if (Character.isLetterOrDigit(ch)) {
+                normalized.append(Character.toLowerCase(ch));
+            }
+        }
+        return normalized.toString();
     }
 
     private static final class DateRange {

--- a/src/test/java/com/example/motorreporting/HtmlReportGeneratorHeaderTest.java
+++ b/src/test/java/com/example/motorreporting/HtmlReportGeneratorHeaderTest.java
@@ -1,0 +1,45 @@
+package com.example.motorreporting;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HtmlReportGeneratorHeaderTest {
+
+    @Test
+    void headerUsesQuoteRequestedOnRangeWhenHeaderContainsSpaces(@TempDir Path tempDir) throws IOException {
+        Map<String, String> firstRow = new HashMap<>();
+        firstRow.put("Quote Requested On", "2024-01-05 08:15");
+        firstRow.put("InsuranceType", "TPL");
+        firstRow.put("Status", "Success");
+        firstRow.put("QuotationNo", "QTN-0001");
+
+        Map<String, String> secondRow = new HashMap<>();
+        secondRow.put("Quote Requested On", "2024-01-11 16:05");
+        secondRow.put("InsuranceType", "Comprehensive");
+        secondRow.put("Status", "Failed");
+        secondRow.put("ErrorText", "Vehicle inspection required");
+
+        List<QuoteRecord> records = List.of(
+                QuoteRecord.fromValues(firstRow),
+                QuoteRecord.fromValues(secondRow)
+        );
+
+        QuoteStatistics statistics = QuoteStatisticsCalculator.calculate(records);
+
+        HtmlReportGenerator generator = new HtmlReportGenerator();
+        Path output = tempDir.resolve("report.html");
+        generator.generate(output, statistics, records);
+
+        String html = Files.readString(output);
+        assertTrue(html.contains("Overview of Quote requests Analysis from 2024-01-05 to 2024-01-11"));
+    }
+}


### PR DESCRIPTION
## Summary
- relax the QuoteRequestedOn header matching so HTML reports pick up date ranges even when the column name contains spaces or punctuation
- add a regression test proving the report header shows the requested date range for spaced column names

## Testing
- mvn test *(fails: unable to download org.apache.maven.plugins:maven-resources-plugin:3.3.1 because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68d2795f1740832586895e6f0c5ce4c2