### PR TITLE
Add unique chassis outcome charts per insurance type

### DIFF
--- a/src/main/java/com/example/motorreporting/HtmlReportGenerator.java
+++ b/src/main/java/com/example/motorreporting/HtmlReportGenerator.java
@@ -62,6 +62,10 @@ public class HtmlReportGenerator {
         long uniqueChassisTotal = statistics.getUniqueChassisCount();
         long uniqueChassisSuccess = statistics.getUniqueChassisSuccessCount();
         long uniqueChassisFail = statistics.getUniqueChassisFailCount();
+        long tplUniqueChassisSuccess = statistics.getTplUniqueChassisSuccessCount();
+        long tplUniqueChassisFail = statistics.getTplUniqueChassisFailCount();
+        long compUniqueChassisSuccess = statistics.getComprehensiveUniqueChassisSuccessCount();
+        long compUniqueChassisFail = statistics.getComprehensiveUniqueChassisFailCount();
         String headerText = buildHeaderText(records);
 
         StringBuilder html = new StringBuilder();
@@ -224,13 +228,19 @@ public class HtmlReportGenerator {
         html.append("        <canvas id=\"compOutcomesChart\"></canvas>\n");
         html.append("      </div>\n");
         html.append("      <div class=\"chart-card\">\n");
-        html.append("        <h2>Unique Chassis Outcomes</h2>\n");
-        html.append("        <canvas id=\"uniqueChassisChart\"></canvas>\n");
+        html.append("        <h2>TPL Success vs Failed (Unique Chassis)</h2>\n");
+        html.append("        <canvas id=\"tplUniqueChassisChart\"></canvas>\n");
+        html.append("      </div>\n");
+        html.append("      <div class=\"chart-card\">\n");
+        html.append("        <h2>Comprehensive Success vs Failed (Unique Chassis)</h2>\n");
+        html.append("        <canvas id=\"compUniqueChassisChart\"></canvas>\n");
         html.append("      </div>\n");
         html.append("    </div>\n");
         html.append("  </section>\n");
         html.append("</main>\n");
-        html.append(buildScripts(tplStats, compStats, uniqueChassisTotal, uniqueChassisSuccess, uniqueChassisFail));
+        html.append(buildScripts(tplStats, compStats,
+                tplUniqueChassisSuccess, tplUniqueChassisFail,
+                compUniqueChassisSuccess, compUniqueChassisFail));
         html.append("</body>\n");
         html.append("</html>\n");
         return html.toString();
@@ -367,9 +377,10 @@ public class HtmlReportGenerator {
 
     private String buildScripts(QuoteGroupStats tplStats,
                                 QuoteGroupStats compStats,
-                                long uniqueChassisTotal,
-                                long uniqueChassisSuccess,
-                                long uniqueChassisFail) {
+                                long tplUniqueChassisSuccess,
+                                long tplUniqueChassisFail,
+                                long compUniqueChassisSuccess,
+                                long compUniqueChassisFail) {
         StringBuilder script = new StringBuilder();
         script.append("<script src=\"https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js\"></script>\n");
         script.append("<script>\n");
@@ -404,13 +415,23 @@ public class HtmlReportGenerator {
         script.append("      borderRadius: 8\n");
         script.append("    }]\n");
         script.append("  };\n");
-        script.append("  const uniqueChassisData = {\n");
-        script.append("    labels: ['Total Unique', 'Success', 'Failed'],\n");
+        script.append("  const tplUniqueChassisData = {\n");
+        script.append("    labels: ['Success', 'Failed'],\n");
         script.append("    datasets: [{\n");
         script.append("      label: 'Unique chassis',\n");
-        script.append("      data: [").append(uniqueChassisTotal).append(',')
-                .append(uniqueChassisSuccess).append(',').append(uniqueChassisFail).append("],\n");
-        script.append("      backgroundColor: ['#2563eb', '#16a34a', '#dc2626'],\n");
+        script.append("      data: [").append(tplUniqueChassisSuccess).append(',')
+                .append(tplUniqueChassisFail).append("],\n");
+        script.append("      backgroundColor: ['#16a34a', '#dc2626'],\n");
+        script.append("      borderRadius: 8\n");
+        script.append("    }]\n");
+        script.append("  };\n");
+        script.append("  const compUniqueChassisData = {\n");
+        script.append("    labels: ['Success', 'Failed'],\n");
+        script.append("    datasets: [{\n");
+        script.append("      label: 'Unique chassis',\n");
+        script.append("      data: [").append(compUniqueChassisSuccess).append(',')
+                .append(compUniqueChassisFail).append("],\n");
+        script.append("      backgroundColor: ['#16a34a', '#dc2626'],\n");
         script.append("      borderRadius: 8\n");
         script.append("    }]\n");
         script.append("  };\n");
@@ -424,9 +445,14 @@ public class HtmlReportGenerator {
         script.append("    data: compData,\n");
         script.append("    options: sharedOptions\n");
         script.append("  });\n");
-        script.append("  new Chart(document.getElementById('uniqueChassisChart'), {\n");
+        script.append("  new Chart(document.getElementById('tplUniqueChassisChart'), {\n");
         script.append("    type: 'bar',\n");
-        script.append("    data: uniqueChassisData,\n");
+        script.append("    data: tplUniqueChassisData,\n");
+        script.append("    options: sharedOptions\n");
+        script.append("  });\n");
+        script.append("  new Chart(document.getElementById('compUniqueChassisChart'), {\n");
+        script.append("    type: 'bar',\n");
+        script.append("    data: compUniqueChassisData,\n");
         script.append("    options: sharedOptions\n");
         script.append("  });\n");
         script.append("</script>\n");

--- a/src/main/java/com/example/motorreporting/QuoteStatistics.java
+++ b/src/main/java/com/example/motorreporting/QuoteStatistics.java
@@ -19,17 +19,29 @@ public class QuoteStatistics {
     private final long uniqueChassisCount;
     private final long uniqueChassisSuccessCount;
     private final long uniqueChassisFailCount;
+    private final long tplUniqueChassisSuccessCount;
+    private final long tplUniqueChassisFailCount;
+    private final long comprehensiveUniqueChassisSuccessCount;
+    private final long comprehensiveUniqueChassisFailCount;
 
     public QuoteStatistics(QuoteGroupStats tplStats,
                            QuoteGroupStats comprehensiveStats,
                            long uniqueChassisCount,
                            long uniqueChassisSuccessCount,
-                           long uniqueChassisFailCount) {
+                           long uniqueChassisFailCount,
+                           long tplUniqueChassisSuccessCount,
+                           long tplUniqueChassisFailCount,
+                           long comprehensiveUniqueChassisSuccessCount,
+                           long comprehensiveUniqueChassisFailCount) {
         this.tplStats = Objects.requireNonNull(tplStats, "tplStats");
         this.comprehensiveStats = Objects.requireNonNull(comprehensiveStats, "comprehensiveStats");
         this.uniqueChassisCount = uniqueChassisCount;
         this.uniqueChassisSuccessCount = uniqueChassisSuccessCount;
         this.uniqueChassisFailCount = uniqueChassisFailCount;
+        this.tplUniqueChassisSuccessCount = tplUniqueChassisSuccessCount;
+        this.tplUniqueChassisFailCount = tplUniqueChassisFailCount;
+        this.comprehensiveUniqueChassisSuccessCount = comprehensiveUniqueChassisSuccessCount;
+        this.comprehensiveUniqueChassisFailCount = comprehensiveUniqueChassisFailCount;
     }
 
     public QuoteGroupStats getTplStats() {
@@ -62,6 +74,22 @@ public class QuoteStatistics {
 
     public long getUniqueChassisFailCount() {
         return uniqueChassisFailCount;
+    }
+
+    public long getTplUniqueChassisSuccessCount() {
+        return tplUniqueChassisSuccessCount;
+    }
+
+    public long getTplUniqueChassisFailCount() {
+        return tplUniqueChassisFailCount;
+    }
+
+    public long getComprehensiveUniqueChassisSuccessCount() {
+        return comprehensiveUniqueChassisSuccessCount;
+    }
+
+    public long getComprehensiveUniqueChassisFailCount() {
+        return comprehensiveUniqueChassisFailCount;
     }
 
     public long getOverallSkipCount() {

--- a/src/main/java/com/example/motorreporting/QuoteStatisticsCalculator.java
+++ b/src/main/java/com/example/motorreporting/QuoteStatisticsCalculator.java
@@ -32,10 +32,16 @@ public final class QuoteStatisticsCalculator {
         QuoteGroupStats tplStats = buildStats(GroupType.TPL, tplRecords);
         QuoteGroupStats compStats = buildStats(GroupType.COMPREHENSIVE, compRecords);
         UniqueChassisSummary uniqueChassisSummary = computeUniqueChassisSummary(records);
+        UniqueChassisSummary tplUniqueChassisSummary = computeUniqueChassisSummary(tplRecords);
+        UniqueChassisSummary compUniqueChassisSummary = computeUniqueChassisSummary(compRecords);
         return new QuoteStatistics(tplStats, compStats,
                 uniqueChassisSummary.getTotal(),
                 uniqueChassisSummary.getSuccessCount(),
-                uniqueChassisSummary.getFailureCount());
+                uniqueChassisSummary.getFailureCount(),
+                tplUniqueChassisSummary.getSuccessCount(),
+                tplUniqueChassisSummary.getFailureCount(),
+                compUniqueChassisSummary.getSuccessCount(),
+                compUniqueChassisSummary.getFailureCount());
     }
 
     private static QuoteGroupStats buildStats(GroupType groupType, List<QuoteRecord> records) {

--- a/src/test/java/com/example/motorreporting/QuoteStatisticsCalculatorStatusTest.java
+++ b/src/test/java/com/example/motorreporting/QuoteStatisticsCalculatorStatusTest.java
@@ -83,5 +83,9 @@ class QuoteStatisticsCalculatorStatusTest {
         assertEquals(3, statistics.getUniqueChassisCount());
         assertEquals(2, statistics.getUniqueChassisSuccessCount());
         assertEquals(2, statistics.getUniqueChassisFailCount());
+        assertEquals(1, statistics.getTplUniqueChassisSuccessCount());
+        assertEquals(1, statistics.getTplUniqueChassisFailCount());
+        assertEquals(1, statistics.getComprehensiveUniqueChassisSuccessCount());
+        assertEquals(1, statistics.getComprehensiveUniqueChassisFailCount());
     }
 }


### PR DESCRIPTION
## Summary
- extend quote statistics to track unique chassis successes and failures per insurance type
- update the HTML dashboard to render four bar charts covering totals and unique chassis outcomes for TPL and Comprehensive
- adjust unit tests to exercise the new unique chassis metrics

## Testing
- mvn -q test *(fails: unable to reach repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_b_68d28ce624848325bff7e785e06d81b5