### PR TITLE
Add TPL analysis page to HTML report

### DIFF
--- a/src/main/java/com/example/motorreporting/QuoteStatistics.java
+++ b/src/main/java/com/example/motorreporting/QuoteStatistics.java
@@ -2,6 +2,7 @@ package com.example.motorreporting;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -23,6 +24,10 @@ public class QuoteStatistics {
     private final long tplUniqueChassisFailCount;
     private final long comprehensiveUniqueChassisSuccessCount;
     private final long comprehensiveUniqueChassisFailCount;
+    private final Map<String, OutcomeBreakdown> tplBodyCategoryOutcomes;
+    private final Map<String, OutcomeBreakdown> tplSpecificationOutcomes;
+    private final List<AgeRangeStats> tplAgeRangeStats;
+    private final Map<String, Long> tplErrorCounts;
 
     public QuoteStatistics(QuoteGroupStats tplStats,
                            QuoteGroupStats comprehensiveStats,
@@ -32,7 +37,11 @@ public class QuoteStatistics {
                            long tplUniqueChassisSuccessCount,
                            long tplUniqueChassisFailCount,
                            long comprehensiveUniqueChassisSuccessCount,
-                           long comprehensiveUniqueChassisFailCount) {
+                           long comprehensiveUniqueChassisFailCount,
+                           Map<String, OutcomeBreakdown> tplBodyCategoryOutcomes,
+                           Map<String, OutcomeBreakdown> tplSpecificationOutcomes,
+                           List<AgeRangeStats> tplAgeRangeStats,
+                           Map<String, Long> tplErrorCounts) {
         this.tplStats = Objects.requireNonNull(tplStats, "tplStats");
         this.comprehensiveStats = Objects.requireNonNull(comprehensiveStats, "comprehensiveStats");
         this.uniqueChassisCount = uniqueChassisCount;
@@ -42,6 +51,10 @@ public class QuoteStatistics {
         this.tplUniqueChassisFailCount = tplUniqueChassisFailCount;
         this.comprehensiveUniqueChassisSuccessCount = comprehensiveUniqueChassisSuccessCount;
         this.comprehensiveUniqueChassisFailCount = comprehensiveUniqueChassisFailCount;
+        this.tplBodyCategoryOutcomes = Collections.unmodifiableMap(new LinkedHashMap<>(tplBodyCategoryOutcomes));
+        this.tplSpecificationOutcomes = Collections.unmodifiableMap(new LinkedHashMap<>(tplSpecificationOutcomes));
+        this.tplAgeRangeStats = List.copyOf(tplAgeRangeStats);
+        this.tplErrorCounts = Collections.unmodifiableMap(new LinkedHashMap<>(tplErrorCounts));
     }
 
     public QuoteGroupStats getTplStats() {
@@ -90,6 +103,22 @@ public class QuoteStatistics {
 
     public long getComprehensiveUniqueChassisFailCount() {
         return comprehensiveUniqueChassisFailCount;
+    }
+
+    public Map<String, OutcomeBreakdown> getTplBodyCategoryOutcomes() {
+        return tplBodyCategoryOutcomes;
+    }
+
+    public Map<String, OutcomeBreakdown> getTplSpecificationOutcomes() {
+        return tplSpecificationOutcomes;
+    }
+
+    public List<AgeRangeStats> getTplAgeRangeStats() {
+        return tplAgeRangeStats;
+    }
+
+    public Map<String, Long> getTplErrorCounts() {
+        return tplErrorCounts;
     }
 
     public long getOverallSkipCount() {
@@ -152,6 +181,72 @@ public class QuoteStatistics {
             return Integer.parseInt(label);
         } catch (NumberFormatException ex) {
             return Integer.MAX_VALUE;
+        }
+    }
+
+    public static final class OutcomeBreakdown {
+        private final long successCount;
+        private final long failureCount;
+
+        public OutcomeBreakdown(long successCount, long failureCount) {
+            this.successCount = successCount;
+            this.failureCount = failureCount;
+        }
+
+        public long getSuccessCount() {
+            return successCount;
+        }
+
+        public long getFailureCount() {
+            return failureCount;
+        }
+
+        public long getProcessedTotal() {
+            return successCount + failureCount;
+        }
+    }
+
+    public static final class AgeRangeStats {
+        private final String label;
+        private final long successCount;
+        private final long failureCount;
+
+        public AgeRangeStats(String label, long successCount, long failureCount) {
+            this.label = Objects.requireNonNull(label, "label");
+            this.successCount = successCount;
+            this.failureCount = failureCount;
+        }
+
+        public String getLabel() {
+            return label;
+        }
+
+        public long getSuccessCount() {
+            return successCount;
+        }
+
+        public long getFailureCount() {
+            return failureCount;
+        }
+
+        public long getProcessedTotal() {
+            return successCount + failureCount;
+        }
+
+        public double getSuccessRatio() {
+            long total = getProcessedTotal();
+            if (total == 0) {
+                return 0.0;
+            }
+            return (successCount * 100.0) / total;
+        }
+
+        public double getFailureRatio() {
+            long total = getProcessedTotal();
+            if (total == 0) {
+                return 0.0;
+            }
+            return (failureCount * 100.0) / total;
         }
     }
 }

--- a/src/main/java/com/example/motorreporting/QuoteStatisticsCalculator.java
+++ b/src/main/java/com/example/motorreporting/QuoteStatisticsCalculator.java
@@ -2,13 +2,17 @@ package com.example.motorreporting;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -34,6 +38,12 @@ public final class QuoteStatisticsCalculator {
         UniqueChassisSummary uniqueChassisSummary = computeUniqueChassisSummary(records);
         UniqueChassisSummary tplUniqueChassisSummary = computeUniqueChassisSummary(tplRecords);
         UniqueChassisSummary compUniqueChassisSummary = computeUniqueChassisSummary(compRecords);
+        Map<String, QuoteStatistics.OutcomeBreakdown> tplBodyCategoryOutcomes =
+                computeOutcomeBreakdown(tplRecords, QuoteRecord::getBodyCategoryLabel);
+        Map<String, QuoteStatistics.OutcomeBreakdown> tplSpecificationOutcomes =
+                computeOutcomeBreakdown(tplRecords, QuoteRecord::getOverrideSpecificationLabel);
+        List<QuoteStatistics.AgeRangeStats> tplAgeRangeStats = computeTplAgeRangeStats(tplRecords);
+        Map<String, Long> tplErrorCounts = computeTplErrorCounts(tplRecords);
         return new QuoteStatistics(tplStats, compStats,
                 uniqueChassisSummary.getTotal(),
                 uniqueChassisSummary.getSuccessCount(),
@@ -41,7 +51,11 @@ public final class QuoteStatisticsCalculator {
                 tplUniqueChassisSummary.getSuccessCount(),
                 tplUniqueChassisSummary.getFailureCount(),
                 compUniqueChassisSummary.getSuccessCount(),
-                compUniqueChassisSummary.getFailureCount());
+                compUniqueChassisSummary.getFailureCount(),
+                tplBodyCategoryOutcomes,
+                tplSpecificationOutcomes,
+                tplAgeRangeStats,
+                tplErrorCounts);
     }
 
     private static QuoteGroupStats buildStats(GroupType groupType, List<QuoteRecord> records) {
@@ -114,6 +128,89 @@ public final class QuoteStatisticsCalculator {
         return new UniqueChassisSummary(uniqueValues.size(), successValues.size(), failureValues.size());
     }
 
+    private static Map<String, QuoteStatistics.OutcomeBreakdown> computeOutcomeBreakdown(
+            List<QuoteRecord> records,
+            Function<QuoteRecord, String> classifier) {
+        Map<String, OutcomeAccumulator> accumulatorByKey = new HashMap<>();
+        for (QuoteRecord record : records) {
+            if (!record.isSuccessful() && !record.isFailure()) {
+                continue;
+            }
+            String label = classifier.apply(record);
+            if (label == null || label.isBlank()) {
+                label = "Unknown";
+            }
+            OutcomeAccumulator accumulator = accumulatorByKey.computeIfAbsent(label, key -> new OutcomeAccumulator());
+            if (record.isSuccessful()) {
+                accumulator.incrementSuccess();
+            } else {
+                accumulator.incrementFailure();
+            }
+        }
+
+        return accumulatorByKey.entrySet().stream()
+                .sorted(Comparator.<Map.Entry<String, OutcomeAccumulator>>comparingLong(
+                                entry -> entry.getValue().total())
+                        .reversed()
+                        .thenComparing(Map.Entry::getKey))
+                .collect(Collectors.toMap(Map.Entry::getKey,
+                        entry -> entry.getValue().toOutcomeBreakdown(),
+                        (a, b) -> a,
+                        LinkedHashMap::new));
+    }
+
+    private static List<QuoteStatistics.AgeRangeStats> computeTplAgeRangeStats(List<QuoteRecord> records) {
+        Map<AgeRange, OutcomeAccumulator> accumulatorByRange = new LinkedHashMap<>();
+        for (AgeRange range : AGE_RANGES) {
+            accumulatorByRange.put(range, new OutcomeAccumulator());
+        }
+        OutcomeAccumulator otherAccumulator = new OutcomeAccumulator();
+
+        for (QuoteRecord record : records) {
+            if (!record.isSuccessful() && !record.isFailure()) {
+                continue;
+            }
+            OutcomeAccumulator accumulator = otherAccumulator;
+            if (record.getDriverAge().isPresent()) {
+                int age = record.getDriverAge().get();
+                AgeRange matchingRange = findAgeRange(age);
+                if (matchingRange != null) {
+                    accumulator = accumulatorByRange.get(matchingRange);
+                }
+            }
+
+            if (record.isSuccessful()) {
+                accumulator.incrementSuccess();
+            } else {
+                accumulator.incrementFailure();
+            }
+        }
+
+        List<QuoteStatistics.AgeRangeStats> results = new ArrayList<>();
+        for (AgeRange range : AGE_RANGES) {
+            OutcomeAccumulator accumulator = accumulatorByRange.get(range);
+            results.add(accumulator.toAgeRangeStats(range.getLabel()));
+        }
+        if (otherAccumulator.total() > 0) {
+            results.add(otherAccumulator.toAgeRangeStats(OTHER_AGE_LABEL));
+        }
+        return results;
+    }
+
+    private static Map<String, Long> computeTplErrorCounts(List<QuoteRecord> records) {
+        Map<String, Long> counts = records.stream()
+                .filter(QuoteRecord::isFailure)
+                .map(QuoteRecord::getFailureErrorText)
+                .flatMap(Optional::stream)
+                .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+
+        return counts.entrySet().stream()
+                .sorted(Map.Entry.<String, Long>comparingByValue().reversed()
+                        .thenComparing(Map.Entry::getKey))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue,
+                        (a, b) -> a, LinkedHashMap::new));
+    }
+
     private static final class UniqueChassisSummary {
         private final long total;
         private final long successCount;
@@ -135,6 +232,75 @@ public final class QuoteStatisticsCalculator {
 
         private long getFailureCount() {
             return failureCount;
+        }
+    }
+
+    private static final class OutcomeAccumulator {
+        private long success;
+        private long failure;
+
+        private void incrementSuccess() {
+            success++;
+        }
+
+        private void incrementFailure() {
+            failure++;
+        }
+
+        private long total() {
+            return success + failure;
+        }
+
+        private QuoteStatistics.OutcomeBreakdown toOutcomeBreakdown() {
+            return new QuoteStatistics.OutcomeBreakdown(success, failure);
+        }
+
+        private QuoteStatistics.AgeRangeStats toAgeRangeStats(String label) {
+            return new QuoteStatistics.AgeRangeStats(label, success, failure);
+        }
+    }
+
+    private static AgeRange findAgeRange(int age) {
+        for (AgeRange range : AGE_RANGES) {
+            if (range.contains(age)) {
+                return range;
+            }
+        }
+        return null;
+    }
+
+    private static final String OTHER_AGE_LABEL = "Other / Unknown";
+
+    private static final List<AgeRange> AGE_RANGES = List.of(
+            new AgeRange(18, 24),
+            new AgeRange(25, 29),
+            new AgeRange(30, 34),
+            new AgeRange(35, 39),
+            new AgeRange(40, 44),
+            new AgeRange(45, 49),
+            new AgeRange(50, 54),
+            new AgeRange(55, 59),
+            new AgeRange(60, 64),
+            new AgeRange(65, 70)
+    );
+
+    private static final class AgeRange {
+        private final int startInclusive;
+        private final int endInclusive;
+        private final String label;
+
+        private AgeRange(int startInclusive, int endInclusive) {
+            this.startInclusive = startInclusive;
+            this.endInclusive = endInclusive;
+            this.label = startInclusive + "–" + endInclusive;
+        }
+
+        private boolean contains(int value) {
+            return value >= startInclusive && value <= endInclusive;
+        }
+
+        private String getLabel() {
+            return label;
         }
     }
 }


### PR DESCRIPTION
## Summary
- add navigation and a TPL analysis section to the HTML report with dedicated charts and tables for TPL performance
- extend the data model to calculate body category, specification, age, and error breakdowns used by the new charts

## Testing
- mvn -q -DskipTests package *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68d28e7b7c348325a977da7d5f6ac140