### PR TITLE
Add TPL model rejection table

### DIFF
--- a/src/main/java/com/example/motorreporting/HtmlReportGenerator.java
+++ b/src/main/java/com/example/motorreporting/HtmlReportGenerator.java
@@ -362,6 +362,8 @@ public class HtmlReportGenerator {
         html.append("        <canvas id=\"tplAgeRatioChart\"></canvas>\n");
         html.append("      </div>\n");
         html.append("    </div>\n");
+        appendModelChassisTable(html, "Top 10 Rejected Models (Unique Chassis)",
+                statistics.getTplTopRejectedModelsByUniqueChassis());
         appendErrorTable(html, "TPL Error Counts", statistics.getTplErrorCounts());
         html.append("  </section>\n");
         html.append("  <section id=\"comprehensive-analysis\" class=\"page-section\">\n");
@@ -594,6 +596,41 @@ public class HtmlReportGenerator {
                     .append("</td>\n");
             html.append("            <td class=\"numeric\">")
                     .append(escapeHtml(formatPercentage(success, total)))
+                    .append("</td>\n");
+            html.append("          </tr>\n");
+        }
+        html.append("        </tbody>\n");
+        html.append("      </table>\n");
+        html.append("    </div>\n");
+    }
+
+    private void appendModelChassisTable(StringBuilder html,
+                                          String heading,
+                                          List<QuoteStatistics.ModelChassisSummary> models) {
+        html.append("    <div class=\"table-card\">\n");
+        html.append("      <h3>")
+                .append(escapeHtml(heading))
+                .append("</h3>\n");
+        if (models.isEmpty()) {
+            html.append("      <p class=\"empty-state\">No rejected models recorded.</p>\n");
+            html.append("    </div>\n");
+            return;
+        }
+        html.append("      <table>\n");
+        html.append("        <thead>\n");
+        html.append("          <tr>\n");
+        html.append("            <th scope=\"col\">Model</th>\n");
+        html.append("            <th scope=\"col\" class=\"numeric\">Unique Chassis Count</th>\n");
+        html.append("          </tr>\n");
+        html.append("        </thead>\n");
+        html.append("        <tbody>\n");
+        for (QuoteStatistics.ModelChassisSummary summary : models) {
+            html.append("          <tr>\n");
+            html.append("            <td>")
+                    .append(escapeHtml(summary.getModel()))
+                    .append("</td>\n");
+            html.append("            <td class=\"numeric\">")
+                    .append(escapeHtml(formatInteger(summary.getUniqueChassisCount())))
                     .append("</td>\n");
             html.append("          </tr>\n");
         }

--- a/src/main/java/com/example/motorreporting/QuoteRecord.java
+++ b/src/main/java/com/example/motorreporting/QuoteRecord.java
@@ -25,6 +25,7 @@ public class QuoteRecord {
     private final QuoteOutcome outcome;
     private final String bodyCategory;
     private final String overrideSpecification;
+    private final String model;
     private final Integer driverAge;
 
     private QuoteRecord(Map<String, String> rawValues,
@@ -38,7 +39,8 @@ public class QuoteRecord {
                         QuoteOutcome outcome,
                         String bodyCategory,
                         String overrideSpecification,
-                        Integer driverAge) {
+                        Integer driverAge,
+                        String model) {
         this.rawValues = Collections.unmodifiableMap(new HashMap<>(rawValues));
         this.insuranceType = insuranceType;
         this.status = status;
@@ -51,6 +53,7 @@ public class QuoteRecord {
         this.bodyCategory = bodyCategory;
         this.overrideSpecification = overrideSpecification;
         this.driverAge = driverAge;
+        this.model = model;
     }
 
     public static QuoteRecord fromValues(Map<String, String> values) {
@@ -79,9 +82,10 @@ public class QuoteRecord {
         String bodyCategory = normalizeCategoricalValue(getValueIgnoreCase(normalized, "BodyCategory"));
         String overrideSpec = normalizeCategoricalValue(getValueIgnoreCase(normalized, "OverrideIsGccSpec"));
         Integer driverAge = parseInteger(getValueIgnoreCase(normalized, "Age"));
+        String model = normalizeCategoricalValue(getValueIgnoreCase(normalized, "ShoryModelEn"));
 
         return new QuoteRecord(normalized, insuranceType, status, errorText, manufactureYear, estimatedValue,
-                quoteNumber, chassisNumber, outcome, bodyCategory, overrideSpec, driverAge);
+                quoteNumber, chassisNumber, outcome, bodyCategory, overrideSpec, driverAge, model);
     }
 
     private static String getValueIgnoreCase(Map<String, String> values, String key) {
@@ -330,6 +334,14 @@ public class QuoteRecord {
 
     public String getOverrideSpecificationLabel() {
         return labelOrUnknown(overrideSpecification);
+    }
+
+    public Optional<String> getModel() {
+        return Optional.ofNullable(model);
+    }
+
+    public String getModelLabel() {
+        return labelOrUnknown(model);
     }
 
     public Optional<Integer> getDriverAge() {

--- a/src/main/java/com/example/motorreporting/QuoteStatistics.java
+++ b/src/main/java/com/example/motorreporting/QuoteStatistics.java
@@ -31,6 +31,7 @@ public class QuoteStatistics {
     private final List<AgeRangeStats> tplAgeRangeStats;
     private final List<AgeRangeStats> comprehensiveAgeRangeStats;
     private final List<ValueRangeStats> comprehensiveEstimatedValueStats;
+    private final List<ModelChassisSummary> tplTopRejectedModelsByUniqueChassis;
     private final Map<String, Long> tplErrorCounts;
     private final Map<String, Long> comprehensiveErrorCounts;
 
@@ -50,6 +51,7 @@ public class QuoteStatistics {
                            List<AgeRangeStats> tplAgeRangeStats,
                            List<AgeRangeStats> comprehensiveAgeRangeStats,
                            List<ValueRangeStats> comprehensiveEstimatedValueStats,
+                           List<ModelChassisSummary> tplTopRejectedModelsByUniqueChassis,
                            Map<String, Long> tplErrorCounts,
                            Map<String, Long> comprehensiveErrorCounts) {
         this.tplStats = Objects.requireNonNull(tplStats, "tplStats");
@@ -68,6 +70,7 @@ public class QuoteStatistics {
         this.tplAgeRangeStats = List.copyOf(tplAgeRangeStats);
         this.comprehensiveAgeRangeStats = List.copyOf(comprehensiveAgeRangeStats);
         this.comprehensiveEstimatedValueStats = List.copyOf(comprehensiveEstimatedValueStats);
+        this.tplTopRejectedModelsByUniqueChassis = List.copyOf(tplTopRejectedModelsByUniqueChassis);
         this.tplErrorCounts = Collections.unmodifiableMap(new LinkedHashMap<>(tplErrorCounts));
         this.comprehensiveErrorCounts = Collections.unmodifiableMap(new LinkedHashMap<>(comprehensiveErrorCounts));
     }
@@ -130,6 +133,10 @@ public class QuoteStatistics {
 
     public List<AgeRangeStats> getTplAgeRangeStats() {
         return tplAgeRangeStats;
+    }
+
+    public List<ModelChassisSummary> getTplTopRejectedModelsByUniqueChassis() {
+        return tplTopRejectedModelsByUniqueChassis;
     }
 
     public Map<String, Long> getTplErrorCounts() {
@@ -238,6 +245,24 @@ public class QuoteStatistics {
 
         public long getProcessedTotal() {
             return successCount + failureCount;
+        }
+    }
+
+    public static final class ModelChassisSummary {
+        private final String model;
+        private final long uniqueChassisCount;
+
+        public ModelChassisSummary(String model, long uniqueChassisCount) {
+            this.model = Objects.requireNonNull(model, "model");
+            this.uniqueChassisCount = uniqueChassisCount;
+        }
+
+        public String getModel() {
+            return model;
+        }
+
+        public long getUniqueChassisCount() {
+            return uniqueChassisCount;
         }
     }
 


### PR DESCRIPTION
## Summary
- capture the normalized model value when building quote records
- calculate the top rejected TPL models by unique chassis count in the statistics calculator
- render a "Top 10 Rejected Models" table in the TPL analysis section of the HTML report

## Testing
- mvn test *(fails: unable to reach repo.maven.apache.org to download plugins)*

------
https://chatgpt.com/codex/tasks/task_b_68d2950e45288325b0868b5d1ce535b1