### PR TITLE
Add manufacture year outcome ratio reporting

### DIFF
--- a/src/main/java/com/example/motorreporting/ChartCreator.java
+++ b/src/main/java/com/example/motorreporting/ChartCreator.java
@@ -3,12 +3,14 @@ package com.example.motorreporting;
 import org.jfree.chart.ChartFactory;
 import org.jfree.chart.JFreeChart;
 import org.jfree.chart.StandardChartTheme;
+import org.jfree.chart.plot.CategoryPlot;
 import org.jfree.chart.plot.PlotOrientation;
 import org.jfree.chart.title.TextTitle;
 import org.jfree.data.category.DefaultCategoryDataset;
 import org.jfree.data.general.DefaultPieDataset;
 
 import java.awt.*;
+import java.util.List;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
@@ -108,6 +110,35 @@ public final class ChartCreator {
                 false);
         chart.setBackgroundPaint(Color.WHITE);
         chart.getTitle().setFont(new Font("SansSerif", Font.BOLD, 14));
+        return chart;
+    }
+
+    public static JFreeChart createManufactureYearOutcomeChart(String title,
+                                                               List<QuoteStatistics.ManufactureYearStats> stats) {
+        DefaultCategoryDataset dataset = new DefaultCategoryDataset();
+        if (stats == null || stats.isEmpty()) {
+            dataset.addValue(0, "Success %", "No Data");
+            dataset.addValue(0, "Failure %", "No Data");
+        } else {
+            for (QuoteStatistics.ManufactureYearStats stat : stats) {
+                dataset.addValue(stat.getSuccessRatio(), "Success %", stat.getLabel());
+                dataset.addValue(stat.getFailureRatio(), "Failure %", stat.getLabel());
+            }
+        }
+
+        JFreeChart chart = ChartFactory.createLineChart(
+                title,
+                "Manufacture Year",
+                "Percentage",
+                dataset,
+                PlotOrientation.VERTICAL,
+                true,
+                true,
+                false);
+        chart.setBackgroundPaint(Color.WHITE);
+        chart.getTitle().setFont(new Font("SansSerif", Font.BOLD, 14));
+        CategoryPlot plot = chart.getCategoryPlot();
+        plot.getRangeAxis().setRange(0.0, 100.0);
         return chart;
     }
 

--- a/src/main/java/com/example/motorreporting/HtmlReportGenerator.java
+++ b/src/main/java/com/example/motorreporting/HtmlReportGenerator.java
@@ -372,6 +372,12 @@ public class HtmlReportGenerator {
         html.append("        <canvas id=\"tplAgeRatioChart\"></canvas>\n");
         html.append("      </div>\n");
         html.append("    </div>\n");
+        html.append("    <div class=\"charts\">\n");
+        html.append("      <div class=\"chart-card\">\n");
+        html.append("        <h2>Success vs Failure Ratio by Manufacture Year</h2>\n");
+        html.append("        <canvas id=\"tplManufactureYearChart\"></canvas>\n");
+        html.append("      </div>\n");
+        html.append("    </div>\n");
         appendModelChassisTable(html, "Top 10 Rejected Models (Unique Chassis)",
                 statistics.getTplTopRejectedModelsByUniqueChassis());
         appendErrorTable(html, "TPL Error Counts", statistics.getTplErrorCounts());
@@ -417,6 +423,12 @@ public class HtmlReportGenerator {
         html.append("      <div class=\"chart-card\">\n");
         html.append("        <h2>Success vs Failure Ratio by Age Range</h2>\n");
         html.append("        <canvas id=\"compAgeRatioChart\"></canvas>\n");
+        html.append("      </div>\n");
+        html.append("    </div>\n");
+        html.append("    <div class=\"charts\">\n");
+        html.append("      <div class=\"chart-card\">\n");
+        html.append("        <h2>Success vs Failure Ratio by Manufacture Year</h2>\n");
+        html.append("        <canvas id=\"compManufactureYearChart\"></canvas>\n");
         html.append("      </div>\n");
         html.append("    </div>\n");
         html.append("    <div class=\"charts\">\n");
@@ -775,6 +787,10 @@ public class HtmlReportGenerator {
         Map<String, QuoteStatistics.OutcomeBreakdown> compBodyOutcomes = statistics.getComprehensiveBodyCategoryOutcomes();
         List<QuoteStatistics.AgeRangeStats> tplAgeStats = statistics.getTplAgeRangeStats();
         List<QuoteStatistics.AgeRangeStats> compAgeStats = statistics.getComprehensiveAgeRangeStats();
+        List<QuoteStatistics.ManufactureYearStats> tplManufactureYearStats =
+                statistics.getTplManufactureYearStats();
+        List<QuoteStatistics.ManufactureYearStats> compManufactureYearStats =
+                statistics.getComprehensiveManufactureYearStats();
         List<QuoteStatistics.ValueRangeStats> compValueStats = statistics.getComprehensiveEstimatedValueStats();
 
         QuoteStatistics.OutcomeBreakdown tplGccBreakdown =
@@ -869,6 +885,36 @@ public class HtmlReportGenerator {
             compValueLabels.add("No Data");
             compValueSuccessRatios.add(0.0);
             compValueFailureRatios.add(0.0);
+        }
+
+        List<String> tplManufactureYearLabels = new ArrayList<>();
+        List<Double> tplManufactureYearSuccessRatios = new ArrayList<>();
+        List<Double> tplManufactureYearFailureRatios = new ArrayList<>();
+        if (tplManufactureYearStats.isEmpty()) {
+            tplManufactureYearLabels.add("No Data");
+            tplManufactureYearSuccessRatios.add(0.0);
+            tplManufactureYearFailureRatios.add(0.0);
+        } else {
+            for (QuoteStatistics.ManufactureYearStats stat : tplManufactureYearStats) {
+                tplManufactureYearLabels.add(stat.getLabel());
+                tplManufactureYearSuccessRatios.add(stat.getSuccessRatio());
+                tplManufactureYearFailureRatios.add(stat.getFailureRatio());
+            }
+        }
+
+        List<String> compManufactureYearLabels = new ArrayList<>();
+        List<Double> compManufactureYearSuccessRatios = new ArrayList<>();
+        List<Double> compManufactureYearFailureRatios = new ArrayList<>();
+        if (compManufactureYearStats.isEmpty()) {
+            compManufactureYearLabels.add("No Data");
+            compManufactureYearSuccessRatios.add(0.0);
+            compManufactureYearFailureRatios.add(0.0);
+        } else {
+            for (QuoteStatistics.ManufactureYearStats stat : compManufactureYearStats) {
+                compManufactureYearLabels.add(stat.getLabel());
+                compManufactureYearSuccessRatios.add(stat.getSuccessRatio());
+                compManufactureYearFailureRatios.add(stat.getFailureRatio());
+            }
         }
 
         StringBuilder script = new StringBuilder();
@@ -1003,6 +1049,48 @@ public class HtmlReportGenerator {
         script.append("      borderRadius: 8\n");
         script.append("    }]\n");
         script.append("  };\n");
+        script.append("  const tplManufactureYearData = {\n");
+        script.append("    labels: ").append(toJsStringArray(tplManufactureYearLabels)).append(",\n");
+        script.append("    datasets: [\n");
+        script.append("      {\n");
+        script.append("        label: 'Success %',\n");
+        script.append("        data: ").append(toJsDoubleArray(tplManufactureYearSuccessRatios)).append(",\n");
+        script.append("        borderColor: '#16a34a',\n");
+        script.append("        backgroundColor: 'rgba(22, 163, 74, 0.15)',\n");
+        script.append("        tension: 0.35,\n");
+        script.append("        fill: true\n");
+        script.append("      },\n");
+        script.append("      {\n");
+        script.append("        label: 'Failure %',\n");
+        script.append("        data: ").append(toJsDoubleArray(tplManufactureYearFailureRatios)).append(",\n");
+        script.append("        borderColor: '#dc2626',\n");
+        script.append("        backgroundColor: 'rgba(220, 38, 38, 0.15)',\n");
+        script.append("        tension: 0.35,\n");
+        script.append("        fill: true\n");
+        script.append("      }\n");
+        script.append("    ]\n");
+        script.append("  };\n");
+        script.append("  const compManufactureYearData = {\n");
+        script.append("    labels: ").append(toJsStringArray(compManufactureYearLabels)).append(",\n");
+        script.append("    datasets: [\n");
+        script.append("      {\n");
+        script.append("        label: 'Success %',\n");
+        script.append("        data: ").append(toJsDoubleArray(compManufactureYearSuccessRatios)).append(",\n");
+        script.append("        borderColor: '#16a34a',\n");
+        script.append("        backgroundColor: 'rgba(22, 163, 74, 0.15)',\n");
+        script.append("        tension: 0.35,\n");
+        script.append("        fill: true\n");
+        script.append("      },\n");
+        script.append("      {\n");
+        script.append("        label: 'Failure %',\n");
+        script.append("        data: ").append(toJsDoubleArray(compManufactureYearFailureRatios)).append(",\n");
+        script.append("        borderColor: '#dc2626',\n");
+        script.append("        backgroundColor: 'rgba(220, 38, 38, 0.15)',\n");
+        script.append("        tension: 0.35,\n");
+        script.append("        fill: true\n");
+        script.append("      }\n");
+        script.append("    ]\n");
+        script.append("  };\n");
         script.append("  const tplAgeRatioData = {\n");
         script.append("    labels: ").append(toJsStringArray(tplAgeLabels)).append(",\n");
         script.append("    datasets: [\n");
@@ -1078,6 +1166,16 @@ public class HtmlReportGenerator {
         script.append("  new Chart(document.getElementById('compBodyFailureChart'), { type: 'bar', data: compBodyFailureData, options: sharedOptions });\n");
         script.append("  new Chart(document.getElementById('compSpecGccChart'), { type: 'bar', data: compSpecGccData, options: sharedOptions });\n");
         script.append("  new Chart(document.getElementById('compSpecNonGccChart'), { type: 'bar', data: compSpecNonGccData, options: sharedOptions });\n");
+        script.append("  new Chart(document.getElementById('tplManufactureYearChart'), {\n");
+        script.append("    type: 'line',\n");
+        script.append("    data: tplManufactureYearData,\n");
+        script.append("    options: ratioChartOptions\n");
+        script.append("  });\n");
+        script.append("  new Chart(document.getElementById('compManufactureYearChart'), {\n");
+        script.append("    type: 'line',\n");
+        script.append("    data: compManufactureYearData,\n");
+        script.append("    options: ratioChartOptions\n");
+        script.append("  });\n");
         script.append("  new Chart(document.getElementById('tplAgeRatioChart'), {\n");
         script.append("    type: 'line',\n");
         script.append("    data: tplAgeRatioData,\n");

--- a/src/main/java/com/example/motorreporting/PdfReportGenerator.java
+++ b/src/main/java/com/example/motorreporting/PdfReportGenerator.java
@@ -24,6 +24,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.text.DecimalFormat;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -52,13 +53,15 @@ public class PdfReportGenerator {
                 addTitlePage(document);
                 addGroupPart(document,
                         "Part 1 - " + statistics.getTplStats().getGroupType().getDisplayName(),
-                        statistics.getTplStats());
+                        statistics.getTplStats(),
+                        statistics.getTplManufactureYearStats());
 
                 document.newPage();
 
                 addGroupPart(document,
                         "Part 2 - " + statistics.getComprehensiveStats().getGroupType().getDisplayName(),
-                        statistics.getComprehensiveStats());
+                        statistics.getComprehensiveStats(),
+                        statistics.getComprehensiveManufactureYearStats());
 
                 document.newPage();
 
@@ -99,7 +102,10 @@ public class PdfReportGenerator {
         addSpacing(document);
     }
 
-    private void addGroupPart(Document document, String partTitle, QuoteGroupStats stats)
+    private void addGroupPart(Document document,
+                              String partTitle,
+                              QuoteGroupStats stats,
+                              List<QuoteStatistics.ManufactureYearStats> manufactureYearStats)
             throws DocumentException, IOException {
         Paragraph header = new Paragraph(partTitle, SECTION_FONT);
         document.add(header);
@@ -170,6 +176,16 @@ public class PdfReportGenerator {
 
         JFreeChart yearChart = ChartCreator.createFailureByYearBarChart(stats);
         addChart(document, yearChart, 520, 320);
+        addSpacing(document);
+
+        Paragraph ratioHeader = new Paragraph("Success vs Failure Ratio by Manufacture Year", SUBTITLE_FONT);
+        document.add(ratioHeader);
+        addSpacing(document);
+
+        JFreeChart ratioChart = ChartCreator.createManufactureYearOutcomeChart(
+                stats.getGroupType().getDisplayName() + " - Success vs Failure Ratio by Manufacture Year",
+                manufactureYearStats);
+        addChart(document, ratioChart, 520, 320);
         addSpacing(document);
     }
 

--- a/src/main/java/com/example/motorreporting/QuoteStatistics.java
+++ b/src/main/java/com/example/motorreporting/QuoteStatistics.java
@@ -30,6 +30,8 @@ public class QuoteStatistics {
     private final Map<String, OutcomeBreakdown> comprehensiveSpecificationOutcomes;
     private final List<AgeRangeStats> tplAgeRangeStats;
     private final List<AgeRangeStats> comprehensiveAgeRangeStats;
+    private final List<ManufactureYearStats> tplManufactureYearStats;
+    private final List<ManufactureYearStats> comprehensiveManufactureYearStats;
     private final List<ValueRangeStats> comprehensiveEstimatedValueStats;
     private final List<ModelChassisSummary> tplTopRejectedModelsByUniqueChassis;
     private final Map<String, Long> tplErrorCounts;
@@ -50,6 +52,8 @@ public class QuoteStatistics {
                            Map<String, OutcomeBreakdown> comprehensiveSpecificationOutcomes,
                            List<AgeRangeStats> tplAgeRangeStats,
                            List<AgeRangeStats> comprehensiveAgeRangeStats,
+                           List<ManufactureYearStats> tplManufactureYearStats,
+                           List<ManufactureYearStats> comprehensiveManufactureYearStats,
                            List<ValueRangeStats> comprehensiveEstimatedValueStats,
                            List<ModelChassisSummary> tplTopRejectedModelsByUniqueChassis,
                            Map<String, Long> tplErrorCounts,
@@ -69,6 +73,8 @@ public class QuoteStatistics {
         this.comprehensiveSpecificationOutcomes = Collections.unmodifiableMap(new LinkedHashMap<>(comprehensiveSpecificationOutcomes));
         this.tplAgeRangeStats = List.copyOf(tplAgeRangeStats);
         this.comprehensiveAgeRangeStats = List.copyOf(comprehensiveAgeRangeStats);
+        this.tplManufactureYearStats = List.copyOf(tplManufactureYearStats);
+        this.comprehensiveManufactureYearStats = List.copyOf(comprehensiveManufactureYearStats);
         this.comprehensiveEstimatedValueStats = List.copyOf(comprehensiveEstimatedValueStats);
         this.tplTopRejectedModelsByUniqueChassis = List.copyOf(tplTopRejectedModelsByUniqueChassis);
         this.tplErrorCounts = Collections.unmodifiableMap(new LinkedHashMap<>(tplErrorCounts));
@@ -157,6 +163,14 @@ public class QuoteStatistics {
 
     public List<ValueRangeStats> getComprehensiveEstimatedValueStats() {
         return comprehensiveEstimatedValueStats;
+    }
+
+    public List<ManufactureYearStats> getTplManufactureYearStats() {
+        return tplManufactureYearStats;
+    }
+
+    public List<ManufactureYearStats> getComprehensiveManufactureYearStats() {
+        return comprehensiveManufactureYearStats;
     }
 
     public Map<String, Long> getComprehensiveErrorCounts() {
@@ -316,6 +330,50 @@ public class QuoteStatistics {
         private final long failureCount;
 
         public ValueRangeStats(String label, long successCount, long failureCount) {
+            this.label = Objects.requireNonNull(label, "label");
+            this.successCount = successCount;
+            this.failureCount = failureCount;
+        }
+
+        public String getLabel() {
+            return label;
+        }
+
+        public long getSuccessCount() {
+            return successCount;
+        }
+
+        public long getFailureCount() {
+            return failureCount;
+        }
+
+        public long getProcessedTotal() {
+            return successCount + failureCount;
+        }
+
+        public double getSuccessRatio() {
+            long total = getProcessedTotal();
+            if (total == 0) {
+                return 0.0;
+            }
+            return (successCount * 100.0) / total;
+        }
+
+        public double getFailureRatio() {
+            long total = getProcessedTotal();
+            if (total == 0) {
+                return 0.0;
+            }
+            return (failureCount * 100.0) / total;
+        }
+    }
+
+    public static final class ManufactureYearStats {
+        private final String label;
+        private final long successCount;
+        private final long failureCount;
+
+        public ManufactureYearStats(String label, long successCount, long failureCount) {
             this.label = Objects.requireNonNull(label, "label");
             this.successCount = successCount;
             this.failureCount = failureCount;


### PR DESCRIPTION
## Summary
- add success and failure aggregation by manufacture year to the statistics model
- show new manufacture year outcome ratio charts in the HTML TPL and Comprehensive sections
- render the same manufacture year ratio chart in the PDF via a new ChartCreator helper

## Testing
- mvn -q test *(fails: unable to reach Maven Central to download plugins)*

------
https://chatgpt.com/codex/tasks/task_b_68d2a8ab9e6c8325abf3b1acf2010480