### PR TITLE
Add overview insights for unique chassis and demand trends

### DIFF
--- a/src/main/java/com/example/motorreporting/QuoteRecord.java
+++ b/src/main/java/com/example/motorreporting/QuoteRecord.java
@@ -17,6 +17,7 @@ public class QuoteRecord {
     private final Map<String, String> rawValues;
     private final String insuranceType;
     private final String status;
+    private final String insurancePurpose;
     private final String errorText;
     private final String quoteNumber;
     private final Integer manufactureYear;
@@ -26,11 +27,13 @@ public class QuoteRecord {
     private final String bodyCategory;
     private final String overrideSpecification;
     private final String model;
+    private final String make;
     private final Integer driverAge;
 
     private QuoteRecord(Map<String, String> rawValues,
                         String insuranceType,
                         String status,
+                        String insurancePurpose,
                         String errorText,
                         Integer manufactureYear,
                         BigDecimal estimatedValue,
@@ -40,10 +43,12 @@ public class QuoteRecord {
                         String bodyCategory,
                         String overrideSpecification,
                         Integer driverAge,
-                        String model) {
+                        String model,
+                        String make) {
         this.rawValues = Collections.unmodifiableMap(new HashMap<>(rawValues));
         this.insuranceType = insuranceType;
         this.status = status;
+        this.insurancePurpose = insurancePurpose;
         this.errorText = errorText;
         this.manufactureYear = manufactureYear;
         this.estimatedValue = estimatedValue;
@@ -52,8 +57,9 @@ public class QuoteRecord {
         this.outcome = Objects.requireNonNull(outcome, "outcome");
         this.bodyCategory = bodyCategory;
         this.overrideSpecification = overrideSpecification;
-        this.driverAge = driverAge;
         this.model = model;
+        this.make = make;
+        this.driverAge = driverAge;
     }
 
     public static QuoteRecord fromValues(Map<String, String> values) {
@@ -75,6 +81,7 @@ public class QuoteRecord {
 
         String insuranceType = getValueIgnoreCase(normalized, "InsuranceType");
         String status = outcome.getDisplayLabel();
+        String insurancePurpose = normalizeCategoricalValue(getValueIgnoreCase(normalized, "InsurancePurpose"));
         Integer manufactureYear = parseInteger(getValueIgnoreCase(normalized, "ManufactureYear"));
         BigDecimal estimatedValue = parseBigDecimal(getValueIgnoreCase(normalized, "EstimatedValue"));
         String quoteNumber = extractQuoteNumber(normalized);
@@ -83,9 +90,10 @@ public class QuoteRecord {
         String overrideSpec = normalizeCategoricalValue(getValueIgnoreCase(normalized, "OverrideIsGccSpec"));
         Integer driverAge = parseInteger(getValueIgnoreCase(normalized, "Age"));
         String model = normalizeCategoricalValue(getValueIgnoreCase(normalized, "ShoryModelEn"));
+        String make = normalizeCategoricalValue(getValueIgnoreCase(normalized, "ShoryMakeEn"));
 
-        return new QuoteRecord(normalized, insuranceType, status, errorText, manufactureYear, estimatedValue,
-                quoteNumber, chassisNumber, outcome, bodyCategory, overrideSpec, driverAge, model);
+        return new QuoteRecord(normalized, insuranceType, status, insurancePurpose, errorText, manufactureYear, estimatedValue,
+                quoteNumber, chassisNumber, outcome, bodyCategory, overrideSpec, driverAge, model, make);
     }
 
     private static String getValueIgnoreCase(Map<String, String> values, String key) {
@@ -316,6 +324,14 @@ public class QuoteRecord {
         return status;
     }
 
+    public Optional<String> getInsurancePurpose() {
+        return Optional.ofNullable(insurancePurpose);
+    }
+
+    public String getInsurancePurposeLabel() {
+        return labelOrUnknown(insurancePurpose);
+    }
+
     public Map<String, String> getRawValues() {
         return rawValues;
     }
@@ -342,6 +358,14 @@ public class QuoteRecord {
 
     public String getModelLabel() {
         return labelOrUnknown(model);
+    }
+
+    public Optional<String> getMake() {
+        return Optional.ofNullable(make);
+    }
+
+    public String getMakeLabel() {
+        return labelOrUnknown(make);
     }
 
     public Optional<Integer> getDriverAge() {

--- a/src/main/java/com/example/motorreporting/QuoteStatistics.java
+++ b/src/main/java/com/example/motorreporting/QuoteStatistics.java
@@ -34,8 +34,13 @@ public class QuoteStatistics {
     private final List<ManufactureYearStats> comprehensiveManufactureYearStats;
     private final List<ValueRangeStats> comprehensiveEstimatedValueStats;
     private final List<ModelChassisSummary> tplTopRejectedModelsByUniqueChassis;
+    private final List<MakeModelChassisSummary> topRequestedMakeModelsByUniqueChassis;
     private final Map<String, Long> tplErrorCounts;
     private final Map<String, Long> comprehensiveErrorCounts;
+    private final List<CategoryCount> uniqueChassisByInsurancePurpose;
+    private final List<CategoryCount> uniqueChassisByBodyType;
+    private final List<CategoryCount> manufactureYearTrend;
+    private final List<CategoryCount> customerAgeTrend;
 
     public QuoteStatistics(QuoteGroupStats tplStats,
                            QuoteGroupStats comprehensiveStats,
@@ -56,8 +61,13 @@ public class QuoteStatistics {
                            List<ManufactureYearStats> comprehensiveManufactureYearStats,
                            List<ValueRangeStats> comprehensiveEstimatedValueStats,
                            List<ModelChassisSummary> tplTopRejectedModelsByUniqueChassis,
+                           List<MakeModelChassisSummary> topRequestedMakeModelsByUniqueChassis,
                            Map<String, Long> tplErrorCounts,
-                           Map<String, Long> comprehensiveErrorCounts) {
+                           Map<String, Long> comprehensiveErrorCounts,
+                           List<CategoryCount> uniqueChassisByInsurancePurpose,
+                           List<CategoryCount> uniqueChassisByBodyType,
+                           List<CategoryCount> manufactureYearTrend,
+                           List<CategoryCount> customerAgeTrend) {
         this.tplStats = Objects.requireNonNull(tplStats, "tplStats");
         this.comprehensiveStats = Objects.requireNonNull(comprehensiveStats, "comprehensiveStats");
         this.uniqueChassisCount = uniqueChassisCount;
@@ -77,8 +87,13 @@ public class QuoteStatistics {
         this.comprehensiveManufactureYearStats = List.copyOf(comprehensiveManufactureYearStats);
         this.comprehensiveEstimatedValueStats = List.copyOf(comprehensiveEstimatedValueStats);
         this.tplTopRejectedModelsByUniqueChassis = List.copyOf(tplTopRejectedModelsByUniqueChassis);
+        this.topRequestedMakeModelsByUniqueChassis = List.copyOf(topRequestedMakeModelsByUniqueChassis);
         this.tplErrorCounts = Collections.unmodifiableMap(new LinkedHashMap<>(tplErrorCounts));
         this.comprehensiveErrorCounts = Collections.unmodifiableMap(new LinkedHashMap<>(comprehensiveErrorCounts));
+        this.uniqueChassisByInsurancePurpose = List.copyOf(uniqueChassisByInsurancePurpose);
+        this.uniqueChassisByBodyType = List.copyOf(uniqueChassisByBodyType);
+        this.manufactureYearTrend = List.copyOf(manufactureYearTrend);
+        this.customerAgeTrend = List.copyOf(customerAgeTrend);
     }
 
     public QuoteGroupStats getTplStats() {
@@ -145,6 +160,10 @@ public class QuoteStatistics {
         return tplTopRejectedModelsByUniqueChassis;
     }
 
+    public List<MakeModelChassisSummary> getTopRequestedMakeModelsByUniqueChassis() {
+        return topRequestedMakeModelsByUniqueChassis;
+    }
+
     public Map<String, Long> getTplErrorCounts() {
         return tplErrorCounts;
     }
@@ -175,6 +194,22 @@ public class QuoteStatistics {
 
     public Map<String, Long> getComprehensiveErrorCounts() {
         return comprehensiveErrorCounts;
+    }
+
+    public List<CategoryCount> getUniqueChassisByInsurancePurpose() {
+        return uniqueChassisByInsurancePurpose;
+    }
+
+    public List<CategoryCount> getUniqueChassisByBodyType() {
+        return uniqueChassisByBodyType;
+    }
+
+    public List<CategoryCount> getManufactureYearTrend() {
+        return manufactureYearTrend;
+    }
+
+    public List<CategoryCount> getCustomerAgeTrend() {
+        return customerAgeTrend;
     }
 
     public long getOverallSkipCount() {
@@ -277,6 +312,48 @@ public class QuoteStatistics {
 
         public long getUniqueChassisCount() {
             return uniqueChassisCount;
+        }
+    }
+
+    public static final class MakeModelChassisSummary {
+        private final String make;
+        private final String model;
+        private final long uniqueChassisCount;
+
+        public MakeModelChassisSummary(String make, String model, long uniqueChassisCount) {
+            this.make = Objects.requireNonNull(make, "make");
+            this.model = Objects.requireNonNull(model, "model");
+            this.uniqueChassisCount = uniqueChassisCount;
+        }
+
+        public String getMake() {
+            return make;
+        }
+
+        public String getModel() {
+            return model;
+        }
+
+        public long getUniqueChassisCount() {
+            return uniqueChassisCount;
+        }
+    }
+
+    public static final class CategoryCount {
+        private final String label;
+        private final long count;
+
+        public CategoryCount(String label, long count) {
+            this.label = Objects.requireNonNull(label, "label");
+            this.count = count;
+        }
+
+        public String getLabel() {
+            return label;
+        }
+
+        public long getCount() {
+            return count;
         }
     }
 


### PR DESCRIPTION
## Summary
- track insurance purpose, make and new aggregated trend metrics in the statistics model
- compute unique chassis counts by purpose/body type and top make-model demand in the calculator
- enhance the overview HTML with additional tables and line charts for manufacture year and customer age trends

## Testing
- `mvn -q -DskipTests package` *(fails: network is unreachable when downloading maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_b_68d2f0eea3f48325af47651e71c4ae18