### PR TITLE
Add make/model tables for TPL and comprehensive analyses

### DIFF
--- a/src/main/java/com/example/motorreporting/HtmlReportGenerator.java
+++ b/src/main/java/com/example/motorreporting/HtmlReportGenerator.java
@@ -380,6 +380,8 @@ public class HtmlReportGenerator {
         html.append("      </div>\n");
         html.append("    </div>\n");
         appendOutcomeTable(html, "Specification Outcomes (GCC vs Non-GCC)", tplSpecificationSummary);
+        appendMakeModelTable(html, "Top 20 Make & Model by Unique Chassis (TPL)",
+                statistics.getTplTopRequestedMakeModelsByUniqueChassis());
         html.append("    <div class=\"charts\">\n");
         html.append("      <div class=\"chart-card\">\n");
         html.append("        <h2>Success vs Failure Ratio by Age Range</h2>\n");
@@ -433,6 +435,8 @@ public class HtmlReportGenerator {
         html.append("      </div>\n");
         html.append("    </div>\n");
         appendOutcomeTable(html, "Comprehensive Specification Outcomes (GCC vs Non-GCC)", compSpecificationSummary);
+        appendMakeModelTable(html, "Top 20 Make & Model by Unique Chassis (Comprehensive)",
+                statistics.getComprehensiveTopRequestedMakeModelsByUniqueChassis());
         html.append("    <div class=\"charts\">\n");
         html.append("      <div class=\"chart-card\">\n");
         html.append("        <h2>Success vs Failure Ratio by Age Range</h2>\n");

--- a/src/main/java/com/example/motorreporting/QuoteStatistics.java
+++ b/src/main/java/com/example/motorreporting/QuoteStatistics.java
@@ -35,6 +35,8 @@ public class QuoteStatistics {
     private final List<ValueRangeStats> comprehensiveEstimatedValueStats;
     private final List<ModelChassisSummary> tplTopRejectedModelsByUniqueChassis;
     private final List<MakeModelChassisSummary> topRequestedMakeModelsByUniqueChassis;
+    private final List<MakeModelChassisSummary> tplTopRequestedMakeModelsByUniqueChassis;
+    private final List<MakeModelChassisSummary> comprehensiveTopRequestedMakeModelsByUniqueChassis;
     private final Map<String, Long> tplErrorCounts;
     private final Map<String, Long> comprehensiveErrorCounts;
     private final List<CategoryCount> uniqueChassisByInsurancePurpose;
@@ -62,6 +64,8 @@ public class QuoteStatistics {
                            List<ValueRangeStats> comprehensiveEstimatedValueStats,
                            List<ModelChassisSummary> tplTopRejectedModelsByUniqueChassis,
                            List<MakeModelChassisSummary> topRequestedMakeModelsByUniqueChassis,
+                           List<MakeModelChassisSummary> tplTopRequestedMakeModelsByUniqueChassis,
+                           List<MakeModelChassisSummary> comprehensiveTopRequestedMakeModelsByUniqueChassis,
                            Map<String, Long> tplErrorCounts,
                            Map<String, Long> comprehensiveErrorCounts,
                            List<CategoryCount> uniqueChassisByInsurancePurpose,
@@ -88,6 +92,9 @@ public class QuoteStatistics {
         this.comprehensiveEstimatedValueStats = List.copyOf(comprehensiveEstimatedValueStats);
         this.tplTopRejectedModelsByUniqueChassis = List.copyOf(tplTopRejectedModelsByUniqueChassis);
         this.topRequestedMakeModelsByUniqueChassis = List.copyOf(topRequestedMakeModelsByUniqueChassis);
+        this.tplTopRequestedMakeModelsByUniqueChassis = List.copyOf(tplTopRequestedMakeModelsByUniqueChassis);
+        this.comprehensiveTopRequestedMakeModelsByUniqueChassis =
+                List.copyOf(comprehensiveTopRequestedMakeModelsByUniqueChassis);
         this.tplErrorCounts = Collections.unmodifiableMap(new LinkedHashMap<>(tplErrorCounts));
         this.comprehensiveErrorCounts = Collections.unmodifiableMap(new LinkedHashMap<>(comprehensiveErrorCounts));
         this.uniqueChassisByInsurancePurpose = List.copyOf(uniqueChassisByInsurancePurpose);
@@ -162,6 +169,14 @@ public class QuoteStatistics {
 
     public List<MakeModelChassisSummary> getTopRequestedMakeModelsByUniqueChassis() {
         return topRequestedMakeModelsByUniqueChassis;
+    }
+
+    public List<MakeModelChassisSummary> getTplTopRequestedMakeModelsByUniqueChassis() {
+        return tplTopRequestedMakeModelsByUniqueChassis;
+    }
+
+    public List<MakeModelChassisSummary> getComprehensiveTopRequestedMakeModelsByUniqueChassis() {
+        return comprehensiveTopRequestedMakeModelsByUniqueChassis;
     }
 
     public Map<String, Long> getTplErrorCounts() {

--- a/src/main/java/com/example/motorreporting/QuoteStatisticsCalculator.java
+++ b/src/main/java/com/example/motorreporting/QuoteStatisticsCalculator.java
@@ -66,6 +66,10 @@ public final class QuoteStatisticsCalculator {
                 computeTopRejectedModelsByUniqueChassis(tplRecords, TOP_REJECTED_MODEL_LIMIT);
         List<QuoteStatistics.MakeModelChassisSummary> topRequestedMakeModels =
                 computeTopMakeModelByUniqueChassis(records, TOP_REQUESTED_MAKE_MODEL_LIMIT);
+        List<QuoteStatistics.MakeModelChassisSummary> tplTopRequestedMakeModels =
+                computeTopMakeModelByUniqueChassis(tplRecords, TOP_REQUESTED_MAKE_MODEL_LIMIT);
+        List<QuoteStatistics.MakeModelChassisSummary> compTopRequestedMakeModels =
+                computeTopMakeModelByUniqueChassis(compRecords, TOP_REQUESTED_MAKE_MODEL_LIMIT);
         List<QuoteStatistics.CategoryCount> uniqueChassisByInsurancePurpose =
                 computeUniqueChassisCounts(records, QuoteRecord::getInsurancePurposeLabel);
         List<QuoteStatistics.CategoryCount> uniqueChassisByBodyType =
@@ -93,6 +97,8 @@ public final class QuoteStatisticsCalculator {
                 compEstimatedValueStats,
                 tplTopRejectedModels,
                 topRequestedMakeModels,
+                tplTopRequestedMakeModels,
+                compTopRequestedMakeModels,
                 tplErrorCounts,
                 compErrorCounts,
                 uniqueChassisByInsurancePurpose,

--- a/src/test/java/com/example/motorreporting/QuoteStatisticsCalculatorStatusTest.java
+++ b/src/test/java/com/example/motorreporting/QuoteStatisticsCalculatorStatusTest.java
@@ -88,4 +88,101 @@ class QuoteStatisticsCalculatorStatusTest {
         assertEquals(1, statistics.getComprehensiveUniqueChassisSuccessCount());
         assertEquals(1, statistics.getComprehensiveUniqueChassisFailCount());
     }
+
+    @Test
+    void topMakeModelSummariesAreSplitByInsuranceType() {
+        QuoteRecord tplSuccess = QuoteRecord.fromValues(Map.of(
+                "InsuranceType", "Third Party",
+                "Status", "Success",
+                "ChassisNumber", "TPL-001",
+                "ShoryMakeEn", "Toyota",
+                "ShoryModelEn", "Corolla"
+        ));
+
+        QuoteRecord tplFailure = QuoteRecord.fromValues(Map.of(
+                "InsuranceType", "Third Party",
+                "Status", "Failed",
+                "ErrorText", "declined",
+                "ChassisNumber", "TPL-002",
+                "ShoryMakeEn", "Toyota",
+                "ShoryModelEn", "Corolla"
+        ));
+
+        QuoteRecord tplSecondSuccess = QuoteRecord.fromValues(Map.of(
+                "InsuranceType", "Third Party",
+                "Status", "Success",
+                "ChassisNumber", "TPL-003",
+                "ShoryMakeEn", "Nissan",
+                "ShoryModelEn", "Sunny"
+        ));
+
+        QuoteRecord compFailure = QuoteRecord.fromValues(Map.of(
+                "InsuranceType", "Comprehensive",
+                "Status", "Failed",
+                "ErrorText", "declined",
+                "ChassisNumber", "COMP-001",
+                "ShoryMakeEn", "Toyota",
+                "ShoryModelEn", "Corolla"
+        ));
+
+        QuoteRecord compSuccess = QuoteRecord.fromValues(Map.of(
+                "InsuranceType", "Comprehensive",
+                "Status", "Success",
+                "ChassisNumber", "COMP-002",
+                "ShoryMakeEn", "Honda",
+                "ShoryModelEn", "Civic"
+        ));
+
+        QuoteRecord compSecondFailure = QuoteRecord.fromValues(Map.of(
+                "InsuranceType", "Comprehensive",
+                "Status", "Failed",
+                "ErrorText", "declined",
+                "ChassisNumber", "COMP-003",
+                "ShoryMakeEn", "Honda",
+                "ShoryModelEn", "Civic"
+        ));
+
+        QuoteStatistics statistics = QuoteStatisticsCalculator.calculate(List.of(
+                tplSuccess,
+                tplFailure,
+                tplSecondSuccess,
+                compFailure,
+                compSuccess,
+                compSecondFailure
+        ));
+
+        List<QuoteStatistics.MakeModelChassisSummary> tplSummaries =
+                statistics.getTplTopRequestedMakeModelsByUniqueChassis();
+        assertEquals(2, tplSummaries.size());
+        QuoteStatistics.MakeModelChassisSummary tplToyota = tplSummaries.get(0);
+        assertEquals("Toyota", tplToyota.getMake());
+        assertEquals("Corolla", tplToyota.getModel());
+        assertEquals(2, tplToyota.getUniqueChassisCount());
+        assertEquals(1, tplToyota.getSuccessfulUniqueChassisCount());
+        assertEquals(1, tplToyota.getFailedUniqueChassisCount());
+
+        QuoteStatistics.MakeModelChassisSummary tplNissan = tplSummaries.get(1);
+        assertEquals("Nissan", tplNissan.getMake());
+        assertEquals("Sunny", tplNissan.getModel());
+        assertEquals(1, tplNissan.getUniqueChassisCount());
+        assertEquals(1, tplNissan.getSuccessfulUniqueChassisCount());
+        assertEquals(0, tplNissan.getFailedUniqueChassisCount());
+
+        List<QuoteStatistics.MakeModelChassisSummary> compSummaries =
+                statistics.getComprehensiveTopRequestedMakeModelsByUniqueChassis();
+        assertEquals(2, compSummaries.size());
+        QuoteStatistics.MakeModelChassisSummary compHonda = compSummaries.get(0);
+        assertEquals("Honda", compHonda.getMake());
+        assertEquals("Civic", compHonda.getModel());
+        assertEquals(2, compHonda.getUniqueChassisCount());
+        assertEquals(1, compHonda.getSuccessfulUniqueChassisCount());
+        assertEquals(1, compHonda.getFailedUniqueChassisCount());
+
+        QuoteStatistics.MakeModelChassisSummary compToyota = compSummaries.get(1);
+        assertEquals("Toyota", compToyota.getMake());
+        assertEquals("Corolla", compToyota.getModel());
+        assertEquals(1, compToyota.getUniqueChassisCount());
+        assertEquals(0, compToyota.getSuccessfulUniqueChassisCount());
+        assertEquals(1, compToyota.getFailedUniqueChassisCount());
+    }
 }


### PR DESCRIPTION
## Summary
- add per-group top make/model tables to the TPL and Comprehensive sections of the HTML report
- expose group-specific make/model unique chassis summaries from the statistics calculator
- cover the new statistics with a unit test to ensure group separation

## Testing
- mvn test *(fails: network unreachable while downloading Maven plugins)*

------
https://chatgpt.com/codex/tasks/task_b_68d2f6857cc08325919692d5631888f9