### PR TITLE
Handle CSV encodings with fallbacks

### DIFF
--- a/src/main/java/com/example/motorreporting/QuoteDataLoader.java
+++ b/src/main/java/com/example/motorreporting/QuoteDataLoader.java
@@ -10,17 +10,23 @@ import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.usermodel.WorkbookFactory;
 
+import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.charset.Charset;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Locale;
+import java.util.Set;
 
 /**
  * Loads quote data from either Excel or CSV files.
@@ -140,8 +146,31 @@ public final class QuoteDataLoader {
     }
 
     private static List<QuoteRecord> loadFromCsv(Path filePath) throws IOException {
+        List<Charset> candidateCharsets = buildCandidateCharsets(filePath);
+        CharacterCodingException lastCodingException = null;
+        IOException lastIoException = null;
+        for (Charset charset : candidateCharsets) {
+            try {
+                return readCsvWithCharset(filePath, charset);
+            } catch (CharacterCodingException ex) {
+                lastCodingException = ex;
+            } catch (IOException ex) {
+                lastIoException = ex;
+                break;
+            }
+        }
+        if (lastCodingException != null) {
+            throw new IOException("Unable to read CSV file: " + filePath, lastCodingException);
+        }
+        if (lastIoException != null) {
+            throw lastIoException;
+        }
+        throw new IOException("Unable to read CSV file: " + filePath);
+    }
+
+    private static List<QuoteRecord> readCsvWithCharset(Path filePath, Charset charset) throws IOException {
         List<QuoteRecord> records = new ArrayList<>();
-        try (Reader reader = Files.newBufferedReader(filePath);
+        try (Reader reader = Files.newBufferedReader(filePath, charset);
              CSVReader csvReader = new CSVReaderBuilder(reader)
                      .withCSVParser(new CSVParserBuilder().withSeparator(',').build())
                      .build()) {
@@ -174,10 +203,53 @@ public final class QuoteDataLoader {
                 }
                 records.add(QuoteRecord.fromValues(values));
             }
-        } catch (Exception ex) {
+        } catch (RuntimeException ex) {
             throw new IOException("Unable to read CSV file: " + filePath, ex);
         }
         return records;
+    }
+
+    private static List<Charset> buildCandidateCharsets(Path filePath) {
+        LinkedHashSet<Charset> candidates = new LinkedHashSet<>();
+        Charset bomCharset = detectBomCharset(filePath);
+        if (bomCharset != null) {
+            candidates.add(bomCharset);
+        }
+        candidates.add(StandardCharsets.UTF_8);
+        candidates.add(StandardCharsets.UTF_16LE);
+        candidates.add(StandardCharsets.UTF_16BE);
+        addCharsetIfAvailable(candidates, "windows-1252");
+        candidates.add(StandardCharsets.ISO_8859_1);
+        return new ArrayList<>(candidates);
+    }
+
+    private static Charset detectBomCharset(Path filePath) {
+        try (BufferedInputStream inputStream = new BufferedInputStream(Files.newInputStream(filePath))) {
+            inputStream.mark(3);
+            int first = inputStream.read();
+            int second = inputStream.read();
+            int third = inputStream.read();
+            if (first == 0xFF && second == 0xFE) {
+                return StandardCharsets.UTF_16LE;
+            }
+            if (first == 0xFE && second == 0xFF) {
+                return StandardCharsets.UTF_16BE;
+            }
+            if (first == 0xEF && second == 0xBB && third == 0xBF) {
+                return StandardCharsets.UTF_8;
+            }
+        } catch (IOException ex) {
+            return null;
+        }
+        return null;
+    }
+
+    private static void addCharsetIfAvailable(Set<Charset> target, String charsetName) {
+        try {
+            target.add(Charset.forName(charsetName));
+        } catch (IllegalArgumentException ex) {
+            // Ignore unsupported charsets.
+        }
     }
 
     private static boolean isRowEmpty(String[] row) {

--- a/src/test/java/com/example/motorreporting/QuoteDataLoaderCsvEncodingTest.java
+++ b/src/test/java/com/example/motorreporting/QuoteDataLoaderCsvEncodingTest.java
@@ -1,0 +1,43 @@
+package com.example.motorreporting;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class QuoteDataLoaderCsvEncodingTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void readsUtf16LeEncodedFiles() throws IOException {
+        Path csvFile = tempDir.resolve("utf16.csv");
+        String content = String.join("\n",
+                "Name,Status",
+                "Alice,Success",
+                "Bob,Failed"
+        ) + "\n";
+
+        byte[] bom = new byte[]{(byte) 0xFF, (byte) 0xFE};
+        byte[] data = content.getBytes(StandardCharsets.UTF_16LE);
+        byte[] combined = new byte[bom.length + data.length];
+        System.arraycopy(bom, 0, combined, 0, bom.length);
+        System.arraycopy(data, 0, combined, bom.length, data.length);
+        Files.write(csvFile, combined);
+
+        List<QuoteRecord> records = QuoteDataLoader.load(csvFile);
+
+        assertEquals(2, records.size());
+        assertEquals("Alice", records.get(0).getRawValues().get("Name"));
+        assertEquals("Success", records.get(0).getRawValues().get("Status"));
+        assertEquals("Bob", records.get(1).getRawValues().get("Name"));
+        assertEquals("Failed", records.get(1).getRawValues().get("Status"));
+    }
+}


### PR DESCRIPTION
## Summary
- allow QuoteDataLoader to retry reading CSV files using multiple character sets and detect BOM hints
- add a unit test verifying that UTF-16LE encoded CSV files are loaded correctly

## Testing
- mvn -q test *(fails: unable to download Maven resources plugin because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68d2fe31229483259c99a5c0985468ed