### PR TITLE
Improve guidance when multiple source data files exist

### DIFF
--- a/src/main/java/com/example/motorreporting/QuoteReportGenerator.java
+++ b/src/main/java/com/example/motorreporting/QuoteReportGenerator.java
@@ -8,6 +8,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.stream.Collectors;
 
 /**
  * Application entry point.
@@ -117,8 +118,13 @@ public final class QuoteReportGenerator {
                     + sourceDirectory.toAbsolutePath());
         }
         if (candidates.size() > 1) {
+            String availableFiles = candidates.stream()
+                    .map(path -> path.getFileName().toString())
+                    .sorted()
+                    .collect(Collectors.joining(", "));
             throw new IllegalArgumentException("Multiple data files found in source data directory: "
-                    + sourceDirectory.toAbsolutePath() + ". Please specify which file to use.");
+                    + sourceDirectory.toAbsolutePath() + " (" + availableFiles
+                    + "). Please specify which file to use.");
         }
         return candidates.get(0);
     }

--- a/src/test/java/com/example/motorreporting/QuoteReportGeneratorInputResolutionTest.java
+++ b/src/test/java/com/example/motorreporting/QuoteReportGeneratorInputResolutionTest.java
@@ -1,0 +1,37 @@
+package com.example.motorreporting;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class QuoteReportGeneratorInputResolutionTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void includesCandidateFileNamesWhenMultipleOptionsExist() throws IOException {
+        Path sourceDataDirectory = Files.createDirectories(tempDir.resolve("source data"));
+        Files.createFile(sourceDataDirectory.resolve("alpha.csv"));
+        Files.createFile(sourceDataDirectory.resolve("beta.xlsx"));
+
+        String originalUserDir = System.getProperty("user.dir");
+        System.setProperty("user.dir", tempDir.toString());
+        try {
+            IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                    () -> QuoteReportGenerator.resolveInputPath(null));
+            String message = exception.getMessage();
+            assertTrue(message.contains("alpha.csv"));
+            assertTrue(message.contains("beta.xlsx"));
+        } finally {
+            System.setProperty("user.dir", originalUserDir);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- include the list of supported files when multiple candidates exist in the default source directory
- add a regression test covering the improved error message for multiple source files

## Testing
- `mvn -q test` *(fails: network is unreachable while resolving Maven plugins)*

------
https://chatgpt.com/codex/tasks/task_b_68d39e095cec832588c09a0fa8a4dccf