### PR TITLE
Handle Excel CSV separator directive

### DIFF
--- a/src/main/java/com/example/motorreporting/QuoteDataLoader.java
+++ b/src/main/java/com/example/motorreporting/QuoteDataLoader.java
@@ -266,7 +266,7 @@ public final class QuoteDataLoader {
     private static List<QuoteRecord> readCsvRecords(CSVReader csvReader) throws IOException {
         List<QuoteRecord> records = new ArrayList<>();
         try {
-            String[] headers = csvReader.readNext();
+            String[] headers = readHeaderRow(csvReader);
             if (headers == null) {
                 return records;
             }
@@ -303,6 +303,30 @@ public final class QuoteDataLoader {
             throw new IOException("Unable to parse CSV file", ex);
         }
         return records;
+    }
+
+    private static String[] readHeaderRow(CSVReader csvReader) throws IOException, CsvValidationException {
+        String[] headers = csvReader.readNext();
+        while (headers != null) {
+            if (isRowEmpty(headers) || isSeparatorDirective(headers)) {
+                headers = csvReader.readNext();
+                continue;
+            }
+            break;
+        }
+        return headers;
+    }
+
+    private static boolean isSeparatorDirective(String[] row) {
+        if (row.length != 1) {
+            return false;
+        }
+        String value = row[0];
+        if (value == null) {
+            return false;
+        }
+        String trimmed = stripBom(value).trim();
+        return trimmed.regionMatches(true, 0, "sep=", 0, 4);
     }
 
     private static List<Charset> buildCsvCharsetCandidates(Path filePath) throws IOException {

--- a/src/test/java/com/example/motorreporting/QuoteDataLoaderCsvSeparatorDirectiveTest.java
+++ b/src/test/java/com/example/motorreporting/QuoteDataLoaderCsvSeparatorDirectiveTest.java
@@ -1,0 +1,42 @@
+package com.example.motorreporting;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class QuoteDataLoaderCsvSeparatorDirectiveTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void skipsExcelSeparatorDirectiveRows() throws IOException {
+        Path csvFile = tempDir.resolve("quotes_sep.csv");
+        List<String> lines = List.of(
+                "sep=,",
+                "QuoteRequestedOn,Status,QuotationNo",
+                "2024-01-05 08:15,Success,Q-123"
+        );
+        Files.write(csvFile, lines, StandardCharsets.UTF_8);
+
+        List<QuoteRecord> records = QuoteDataLoader.load(csvFile);
+
+        assertEquals(1, records.size(), "Expected one record after ignoring the separator directive");
+
+        QuoteRecord record = records.get(0);
+        Map<String, String> raw = record.getRawValues();
+        assertTrue(raw.containsKey("QuoteRequestedOn"));
+        assertEquals("2024-01-05 08:15", raw.get("QuoteRequestedOn"));
+        assertEquals("Success", record.getStatus());
+        assertEquals("Q-123", raw.get("QuotationNo"));
+    }
+}


### PR DESCRIPTION
## Summary
- ignore Excel CSV "sep=" directives when determining headers so cleaned exports include data
- add a regression test covering the separator directive case

## Testing
- `mvn test` *(fails: Maven could not download org.apache.maven.plugins:maven-resources-plugin:3.3.1 because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68d3a62ab6bc8325b80f59091c6bdb96