### PR TITLE
Preserve unparsable date values in cleaned export

### DIFF
--- a/src/main/java/com/example/motorreporting/DateNormalizer.java
+++ b/src/main/java/com/example/motorreporting/DateNormalizer.java
@@ -45,6 +45,9 @@ final class DateNormalizer {
         if (trimmed.isEmpty()) {
             return "";
         }
+        if ("null".equalsIgnoreCase(trimmed)) {
+            return "";
+        }
         if (TIME_ONLY_PATTERN.matcher(trimmed).matches()) {
             return "";
         }
@@ -64,7 +67,11 @@ final class DateNormalizer {
             return OUTPUT_FORMAT.format(dateTime);
         }
 
-        return "";
+        if (EXCEL_SERIAL_PATTERN.matcher(trimmed).matches()) {
+            return "";
+        }
+
+        return trimmed;
     }
 
     private static LocalDateTime parseDateTime(String value) {

--- a/src/test/java/com/example/motorreporting/QuoteDataCleanerDateNormalizationTest.java
+++ b/src/test/java/com/example/motorreporting/QuoteDataCleanerDateNormalizationTest.java
@@ -53,4 +53,35 @@ class QuoteDataCleanerDateNormalizationTest {
             assertEquals("Charlie", row[indexByHeader.get("Name")]);
         }
     }
+
+    @Test
+    void retainsOriginalValueWhenDateCannotBeParsed() throws IOException, CsvValidationException {
+        Map<String, String> values = new HashMap<>();
+        values.put("InsuranceExpiryDate", "End of month");
+        values.put("RegistrationDate", "Null");
+        values.put("Status", "");
+        values.put("QuotationNo", "");
+        values.put("ErrorText", "Null");
+        values.put("InsuranceType", "TPL");
+
+        QuoteRecord record = QuoteRecord.fromValues(values);
+
+        Path cleanedFile = QuoteDataCleaner.writeCleanFile(tempDir, List.of(record));
+
+        try (Reader reader = Files.newBufferedReader(cleanedFile, StandardCharsets.UTF_8);
+             CSVReader csvReader = new CSVReader(reader)) {
+            String[] header = csvReader.readNext();
+            String[] row = csvReader.readNext();
+            assertNotNull(header);
+            assertNotNull(row);
+
+            Map<String, Integer> indexByHeader = new HashMap<>();
+            for (int i = 0; i < header.length; i++) {
+                indexByHeader.put(header[i], i);
+            }
+
+            assertEquals("End of month", row[indexByHeader.get("InsuranceExpiryDate")]);
+            assertEquals("", row[indexByHeader.get("RegistrationDate")]);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- keep the original string for date columns that cannot be parsed instead of replacing them with blanks
- continue normalizing recognised formats while treating literal "null" and invalid Excel serial values as empty
- add a regression test to confirm the cleaned CSV retains unparsed dates and still blanks out "Null" placeholders

## Testing
- `mvn -o -Dtest=QuoteDataCleanerDateNormalizationTest test` *(fails: required Maven plugins are not available offline)*

------
https://chatgpt.com/codex/tasks/task_b_68d3a9133c5c8325942e32f581349a01