### PR TITLE
Handle alternate CSV delimiters

### DIFF
--- a/src/test/java/com/example/motorreporting/QuoteDataLoaderCsvDelimiterDetectionTest.java
+++ b/src/test/java/com/example/motorreporting/QuoteDataLoaderCsvDelimiterDetectionTest.java
@@ -1,0 +1,45 @@
+package com.example.motorreporting;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class QuoteDataLoaderCsvDelimiterDetectionTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void detectsSemicolonSeparatedFiles() throws IOException {
+        Path csvFile = tempDir.resolve("quotes_semicolon.csv");
+        List<String> lines = List.of(
+                "QuoteRequestedOn;Status;QuotationNo;EstimatedValue",
+                "2024-01-05 08:15;Success;Q-123;1500",
+                "2024-01-06 10:30;Failed;Q-456;2000"
+        );
+        Files.write(csvFile, lines, StandardCharsets.UTF_8);
+
+        List<QuoteRecord> records = QuoteDataLoader.load(csvFile);
+
+        assertEquals(2, records.size(), "Expected to load records from a semicolon separated CSV");
+
+        QuoteRecord first = records.get(0);
+        Map<String, String> raw = first.getRawValues();
+
+        assertTrue(raw.containsKey("QuoteRequestedOn"));
+        assertEquals("2024-01-05 08:15", raw.get("QuoteRequestedOn"));
+        assertEquals("Success", first.getStatus());
+        assertEquals("Q-123", raw.get("QuotationNo"));
+        assertEquals("1500", raw.get("EstimatedValue"));
+    }
+}
+


### PR DESCRIPTION
## Summary
- detect the delimiter of incoming CSV files before parsing so semicolon-separated exports are loaded correctly
- add a unit test that covers semicolon separated quote data to guard against regressions

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable when downloading maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_b_68d3bb104afc8325b2117ece879a2f2e