### PR TITLE
Add TPL EID/chassis deduplication analysis

### DIFF
--- a/src/main/java/com/example/motorreporting/QuoteStatistics.java
+++ b/src/main/java/com/example/motorreporting/QuoteStatistics.java
@@ -22,6 +22,7 @@ public class QuoteStatistics {
     private final long uniqueChassisFailCount;
     private final long tplUniqueChassisSuccessCount;
     private final long tplUniqueChassisFailCount;
+    private final EidChassisSummary tplEidChassisSummary;
     private final long comprehensiveUniqueChassisSuccessCount;
     private final long comprehensiveUniqueChassisFailCount;
     private final Map<String, OutcomeBreakdown> tplBodyCategoryOutcomes;
@@ -51,6 +52,7 @@ public class QuoteStatistics {
                            long uniqueChassisFailCount,
                            long tplUniqueChassisSuccessCount,
                            long tplUniqueChassisFailCount,
+                           EidChassisSummary tplEidChassisSummary,
                            long comprehensiveUniqueChassisSuccessCount,
                            long comprehensiveUniqueChassisFailCount,
                            Map<String, OutcomeBreakdown> tplBodyCategoryOutcomes,
@@ -79,6 +81,7 @@ public class QuoteStatistics {
         this.uniqueChassisFailCount = uniqueChassisFailCount;
         this.tplUniqueChassisSuccessCount = tplUniqueChassisSuccessCount;
         this.tplUniqueChassisFailCount = tplUniqueChassisFailCount;
+        this.tplEidChassisSummary = Objects.requireNonNull(tplEidChassisSummary, "tplEidChassisSummary");
         this.comprehensiveUniqueChassisSuccessCount = comprehensiveUniqueChassisSuccessCount;
         this.comprehensiveUniqueChassisFailCount = comprehensiveUniqueChassisFailCount;
         this.tplBodyCategoryOutcomes = Collections.unmodifiableMap(new LinkedHashMap<>(tplBodyCategoryOutcomes));
@@ -141,6 +144,22 @@ public class QuoteStatistics {
 
     public long getTplUniqueChassisFailCount() {
         return tplUniqueChassisFailCount;
+    }
+
+    public EidChassisSummary getTplEidChassisSummary() {
+        return tplEidChassisSummary;
+    }
+
+    public long getTplEidChassisTotalRequests() {
+        return tplEidChassisSummary.getTotalRequests();
+    }
+
+    public long getTplEidChassisUniqueRequests() {
+        return tplEidChassisSummary.getUniqueRequests();
+    }
+
+    public long getTplEidChassisDuplicateRequests() {
+        return tplEidChassisSummary.getDuplicateRequests();
     }
 
     public long getComprehensiveUniqueChassisSuccessCount() {
@@ -287,6 +306,30 @@ public class QuoteStatistics {
             return Integer.parseInt(label);
         } catch (NumberFormatException ex) {
             return Integer.MAX_VALUE;
+        }
+    }
+
+    public static final class EidChassisSummary {
+        private final long totalRequests;
+        private final long uniqueRequests;
+        private final long duplicateRequests;
+
+        public EidChassisSummary(long totalRequests, long uniqueRequests, long duplicateRequests) {
+            this.totalRequests = totalRequests;
+            this.uniqueRequests = uniqueRequests;
+            this.duplicateRequests = duplicateRequests;
+        }
+
+        public long getTotalRequests() {
+            return totalRequests;
+        }
+
+        public long getUniqueRequests() {
+            return uniqueRequests;
+        }
+
+        public long getDuplicateRequests() {
+            return duplicateRequests;
         }
     }
 

--- a/src/main/java/com/example/motorreporting/QuoteStatisticsCalculator.java
+++ b/src/main/java/com/example/motorreporting/QuoteStatisticsCalculator.java
@@ -44,6 +44,7 @@ public final class QuoteStatisticsCalculator {
         UniqueChassisSummary uniqueChassisSummary = computeUniqueChassisSummary(records);
         UniqueChassisSummary tplUniqueChassisSummary = computeUniqueChassisSummary(tplRecords);
         UniqueChassisSummary compUniqueChassisSummary = computeUniqueChassisSummary(compRecords);
+        QuoteStatistics.EidChassisSummary tplEidChassisSummary = computeEidChassisSummary(tplRecords);
         Map<String, QuoteStatistics.OutcomeBreakdown> tplBodyCategoryOutcomes =
                 computeOutcomeBreakdown(tplRecords, QuoteRecord::getBodyCategoryLabel);
         Map<String, QuoteStatistics.OutcomeBreakdown> tplSpecificationOutcomes =
@@ -84,6 +85,7 @@ public final class QuoteStatisticsCalculator {
                 uniqueChassisSummary.getFailureCount(),
                 tplUniqueChassisSummary.getSuccessCount(),
                 tplUniqueChassisSummary.getFailureCount(),
+                tplEidChassisSummary,
                 compUniqueChassisSummary.getSuccessCount(),
                 compUniqueChassisSummary.getFailureCount(),
                 tplBodyCategoryOutcomes,
@@ -105,6 +107,25 @@ public final class QuoteStatisticsCalculator {
                 uniqueChassisByBodyType,
                 manufactureYearTrend,
                 customerAgeTrend);
+    }
+
+    private static QuoteStatistics.EidChassisSummary computeEidChassisSummary(List<QuoteRecord> records) {
+        long total = 0;
+        Set<String> uniqueKeys = new LinkedHashSet<>();
+
+        for (QuoteRecord record : records) {
+            Optional<String> eid = record.getEid();
+            Optional<String> chassis = record.getChassisNumber();
+            if (eid.isEmpty() || chassis.isEmpty()) {
+                continue;
+            }
+            total++;
+            uniqueKeys.add(eid.get() + "::" + chassis.get());
+        }
+
+        long unique = uniqueKeys.size();
+        long duplicate = Math.max(0, total - unique);
+        return new QuoteStatistics.EidChassisSummary(total, unique, duplicate);
     }
 
     private static QuoteGroupStats buildStats(GroupType groupType, List<QuoteRecord> records) {


### PR DESCRIPTION
## Summary
- capture normalized EID identifiers on quote records so they can be combined with chassis numbers
- compute TPL-specific EID + chassis request summaries and expose the metrics through the statistics API
- extend the HTML report with a Unique Case Analysis section, chart, and table plus unit coverage for the dedup logic

## Testing
- mvn -q test *(fails: Network is unreachable while downloading maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_b_68d3c7eb18b88325b433aa104b0c4a60