### PR TITLE
Fix chart toggle selector string escaping

### DIFF
--- a/src/main/java/com/example/motorreporting/HtmlReportGenerator.java
+++ b/src/main/java/com/example/motorreporting/HtmlReportGenerator.java
@@ -1196,7 +1196,7 @@ public class HtmlReportGenerator {
         script.append("    data: Array.isArray(dataset.data) ? [...dataset.data] : dataset.data\n");
         script.append("  });\n");
         script.append("  const registerChartToggle = (toggleId, chart, seriesMap) => {\n");
-        script.append("    const toggleElement = document.querySelector(`[data-chart-toggle=\\"${toggleId}\\"]`);\n");
+        script.append("    const toggleElement = document.querySelector(`[data-chart-toggle='${toggleId}']`);\n");
         script.append("    if (!toggleElement) {\n");
         script.append("      return;\n");
         script.append("    }\n");


### PR DESCRIPTION
## Summary
- use single quotes in the generated chart toggle selector to avoid invalid escaping inside the Java string literal

## Testing
- mvn -q -DskipTests package *(fails: network access is disabled in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d4c758193083258766bb5d6826e078