### PR TITLE
Ensure compatibility with Java 8 runtime

### DIFF
--- a/src/main/java/com/example/motorreporting/QuoteDataCleaner.java
+++ b/src/main/java/com/example/motorreporting/QuoteDataCleaner.java
@@ -8,6 +8,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -18,7 +19,7 @@ import java.util.Objects;
  */
 public final class QuoteDataCleaner {
 
-    private static final List<String> DEFAULT_COLUMN_ORDER = List.of(
+    private static final List<String> DEFAULT_COLUMN_ORDER = Arrays.asList(
             "QuoteRequestedOn",
             "Status",
             "ReferenceNumber",

--- a/src/main/java/com/example/motorreporting/QuoteStatistics.java
+++ b/src/main/java/com/example/motorreporting/QuoteStatistics.java
@@ -2,6 +2,7 @@ package com.example.motorreporting;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
@@ -97,22 +98,22 @@ public class QuoteStatistics {
         this.tplSpecificationOutcomes = Collections.unmodifiableMap(new LinkedHashMap<>(tplSpecificationOutcomes));
         this.comprehensiveBodyCategoryOutcomes = Collections.unmodifiableMap(new LinkedHashMap<>(comprehensiveBodyCategoryOutcomes));
         this.comprehensiveSpecificationOutcomes = Collections.unmodifiableMap(new LinkedHashMap<>(comprehensiveSpecificationOutcomes));
-        this.tplAgeRangeStats = List.copyOf(tplAgeRangeStats);
-        this.comprehensiveAgeRangeStats = List.copyOf(comprehensiveAgeRangeStats);
-        this.tplManufactureYearStats = List.copyOf(tplManufactureYearStats);
-        this.comprehensiveManufactureYearStats = List.copyOf(comprehensiveManufactureYearStats);
-        this.comprehensiveEstimatedValueStats = List.copyOf(comprehensiveEstimatedValueStats);
-        this.tplTopRejectedModelsByUniqueChassis = List.copyOf(tplTopRejectedModelsByUniqueChassis);
-        this.topRequestedMakeModelsByUniqueChassis = List.copyOf(topRequestedMakeModelsByUniqueChassis);
-        this.tplTopRequestedMakeModelsByUniqueChassis = List.copyOf(tplTopRequestedMakeModelsByUniqueChassis);
+        this.tplAgeRangeStats = immutableCopy(tplAgeRangeStats);
+        this.comprehensiveAgeRangeStats = immutableCopy(comprehensiveAgeRangeStats);
+        this.tplManufactureYearStats = immutableCopy(tplManufactureYearStats);
+        this.comprehensiveManufactureYearStats = immutableCopy(comprehensiveManufactureYearStats);
+        this.comprehensiveEstimatedValueStats = immutableCopy(comprehensiveEstimatedValueStats);
+        this.tplTopRejectedModelsByUniqueChassis = immutableCopy(tplTopRejectedModelsByUniqueChassis);
+        this.topRequestedMakeModelsByUniqueChassis = immutableCopy(topRequestedMakeModelsByUniqueChassis);
+        this.tplTopRequestedMakeModelsByUniqueChassis = immutableCopy(tplTopRequestedMakeModelsByUniqueChassis);
         this.comprehensiveTopRequestedMakeModelsByUniqueChassis =
-                List.copyOf(comprehensiveTopRequestedMakeModelsByUniqueChassis);
+                immutableCopy(comprehensiveTopRequestedMakeModelsByUniqueChassis);
         this.tplErrorCounts = Collections.unmodifiableMap(new LinkedHashMap<>(tplErrorCounts));
         this.comprehensiveErrorCounts = Collections.unmodifiableMap(new LinkedHashMap<>(comprehensiveErrorCounts));
-        this.uniqueChassisByInsurancePurpose = List.copyOf(uniqueChassisByInsurancePurpose);
-        this.uniqueChassisByBodyType = List.copyOf(uniqueChassisByBodyType);
-        this.manufactureYearTrend = List.copyOf(manufactureYearTrend);
-        this.customerAgeTrend = List.copyOf(customerAgeTrend);
+        this.uniqueChassisByInsurancePurpose = immutableCopy(uniqueChassisByInsurancePurpose);
+        this.uniqueChassisByBodyType = immutableCopy(uniqueChassisByBodyType);
+        this.manufactureYearTrend = immutableCopy(manufactureYearTrend);
+        this.customerAgeTrend = immutableCopy(customerAgeTrend);
     }
 
     public QuoteGroupStats getTplStats() {
@@ -265,6 +266,10 @@ public class QuoteStatistics {
 
     public List<TrendPoint> getCustomerAgeTrend() {
         return customerAgeTrend;
+    }
+
+    private static <T> List<T> immutableCopy(List<T> values) {
+        return Collections.unmodifiableList(new ArrayList<>(values));
     }
 
     public long getOverallSkipCount() {

--- a/src/main/java/com/example/motorreporting/QuoteStatisticsCalculator.java
+++ b/src/main/java/com/example/motorreporting/QuoteStatisticsCalculator.java
@@ -4,6 +4,8 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.Year;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -332,7 +334,8 @@ public final class QuoteStatisticsCalculator {
         Map<String, Long> counts = records.stream()
                 .filter(QuoteRecord::isFailure)
                 .map(QuoteRecord::getFailureErrorText)
-                .flatMap(Optional::stream)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
                 .filter(label -> !excludeNullLabel || !"null".equalsIgnoreCase(label))
                 .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
 
@@ -347,7 +350,7 @@ public final class QuoteStatisticsCalculator {
             List<QuoteRecord> records,
             int limit) {
         if (limit <= 0) {
-            return List.of();
+            return Collections.emptyList();
         }
         Map<String, Set<String>> chassisByModel = new HashMap<>();
         for (QuoteRecord record : records) {
@@ -380,7 +383,7 @@ public final class QuoteStatisticsCalculator {
             List<QuoteRecord> records,
             int limit) {
         if (limit <= 0) {
-            return List.of();
+            return Collections.emptyList();
         }
         Map<MakeModelKey, MakeModelChassisAccumulator> accumulatorByMakeModel = new HashMap<>();
         for (QuoteRecord record : records) {
@@ -447,7 +450,7 @@ public final class QuoteStatisticsCalculator {
         }
 
         if (requestByKey.isEmpty()) {
-            return List.of(new QuoteStatistics.TrendPoint("No Data", 0, 0));
+            return Collections.singletonList(new QuoteStatistics.TrendPoint("No Data", 0, 0));
         }
 
         Map<String, TrendCounter> countsByLabel = new HashMap<>();
@@ -479,7 +482,7 @@ public final class QuoteStatisticsCalculator {
         }
 
         if (requestByKey.isEmpty()) {
-            return List.of(new QuoteStatistics.TrendPoint("No Data", 0, 0));
+            return Collections.singletonList(new QuoteStatistics.TrendPoint("No Data", 0, 0));
         }
 
         Map<String, TrendCounter> countsByLabel = new HashMap<>();
@@ -754,7 +757,7 @@ public final class QuoteStatisticsCalculator {
     private static final String OTHER_AGE_LABEL = "Other / Unknown";
     private static final String OTHER_VALUE_LABEL = "Other / Unknown";
 
-    private static final List<AgeRange> AGE_RANGES = List.of(
+    private static final List<AgeRange> AGE_RANGES = Collections.unmodifiableList(Arrays.asList(
             new AgeRange(18, 24),
             new AgeRange(25, 29),
             new AgeRange(30, 34),
@@ -765,9 +768,9 @@ public final class QuoteStatisticsCalculator {
             new AgeRange(55, 59),
             new AgeRange(60, 64),
             new AgeRange(65, 70)
-    );
+    ));
 
-    private static final List<ValueRange> VALUE_RANGES = List.of(
+    private static final List<ValueRange> VALUE_RANGES = Collections.unmodifiableList(Arrays.asList(
             new ValueRange(5_000, 49_999),
             new ValueRange(50_000, 99_999),
             new ValueRange(100_000, 149_999),
@@ -778,7 +781,7 @@ public final class QuoteStatisticsCalculator {
             new ValueRange(350_000, 399_999),
             new ValueRange(400_000, 449_999),
             new ValueRange(450_000, 500_000)
-    );
+    ));
 
     private static final class ManufactureYearRequest {
         private String label;


### PR DESCRIPTION
## Summary
- replace Java 9 collection factory methods with Java 8-compatible constructs in data cleaning and statistics utilities
- add immutable copy helper to QuoteStatistics to avoid relying on List.copyOf
- adjust optional handling to avoid Optional::stream usage

## Testing
- mvn -q -DskipTests -o compile *(fails: missing maven-resources-plugin artifact in offline environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d4c8e695248325bff7a74f269a5865