### PR TITLE
Fix CSV separator directive handling and statistics comparator errors

### DIFF
--- a/src/main/java/com/example/motorreporting/HtmlReportGenerator.java
+++ b/src/main/java/com/example/motorreporting/HtmlReportGenerator.java
@@ -60,6 +60,13 @@ public class HtmlReportGenerator {
         Files.writeString(outputPath, html, StandardCharsets.UTF_8);
     }
 
+    public void generate(Path outputPath,
+                         QuoteStatistics statistics,
+                         List<QuoteRecord> records) throws IOException {
+        generate(outputPath, statistics, records,
+                ReportDateRange.of(Optional.empty(), Optional.empty()));
+    }
+
     private String buildHtml(QuoteStatistics statistics,
                              List<QuoteRecord> records,
                              ReportDateRange reportDateRange) {

--- a/src/main/java/com/example/motorreporting/QuoteDataLoader.java
+++ b/src/main/java/com/example/motorreporting/QuoteDataLoader.java
@@ -391,15 +391,20 @@ public final class QuoteDataLoader {
     }
 
     private static boolean isSeparatorDirective(String[] row) {
-        if (row.length != 1) {
+        if (row == null || row.length == 0) {
             return false;
         }
-        String value = row[0];
-        if (value == null) {
-            return false;
+        for (String value : row) {
+            if (value == null) {
+                continue;
+            }
+            String trimmed = stripBom(value).trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            return trimmed.regionMatches(true, 0, "sep=", 0, 4);
         }
-        String trimmed = stripBom(value).trim();
-        return trimmed.regionMatches(true, 0, "sep=", 0, 4);
+        return false;
     }
 
     private static List<Charset> buildCsvCharsetCandidates(Path filePath) throws IOException {

--- a/src/main/java/com/example/motorreporting/QuoteReportGenerator.java
+++ b/src/main/java/com/example/motorreporting/QuoteReportGenerator.java
@@ -18,6 +18,14 @@ public final class QuoteReportGenerator {
 
     private static final String DEFAULT_SOURCE_DIRECTORY = "source data";
 
+    private static Path resolveSourceDataDirectory() {
+        String userDir = System.getProperty("user.dir");
+        Path basePath = userDir == null || userDir.isBlank()
+                ? Paths.get(".")
+                : Paths.get(userDir);
+        return basePath.resolve(DEFAULT_SOURCE_DIRECTORY);
+    }
+
     private QuoteReportGenerator() {
     }
 
@@ -58,7 +66,7 @@ public final class QuoteReportGenerator {
             if (Files.exists(provided)) {
                 return provided;
             }
-            Path fromSourceDirectory = Paths.get(DEFAULT_SOURCE_DIRECTORY).resolve(fileName);
+            Path fromSourceDirectory = resolveSourceDataDirectory().resolve(fileName);
             if (Files.exists(fromSourceDirectory)) {
                 return fromSourceDirectory;
             }
@@ -112,7 +120,7 @@ public final class QuoteReportGenerator {
     }
 
     private static Path findSingleFileInSourceDirectory() throws IOException {
-        Path sourceDirectory = Paths.get(DEFAULT_SOURCE_DIRECTORY);
+        Path sourceDirectory = resolveSourceDataDirectory();
         if (!Files.isDirectory(sourceDirectory)) {
             throw new IllegalArgumentException("Source data directory not found: "
                     + sourceDirectory.toAbsolutePath());

--- a/src/main/java/com/example/motorreporting/QuoteStatisticsCalculator.java
+++ b/src/main/java/com/example/motorreporting/QuoteStatisticsCalculator.java
@@ -497,7 +497,8 @@ public final class QuoteStatisticsCalculator {
 
         return countsByLabel.entrySet().stream()
                 .sorted(Comparator
-                        .comparingInt(entry -> yearOrderKey(entry.getKey()))
+                        .comparingInt((Map.Entry<String, TrendCounter> entry) ->
+                                yearOrderKey(entry.getKey()))
                         .thenComparing(Map.Entry::getKey))
                 .map(entry -> new QuoteStatistics.TrendPoint(entry.getKey(),
                         entry.getValue().getTotal(), entry.getValue().getFailed()))
@@ -529,7 +530,8 @@ public final class QuoteStatisticsCalculator {
 
         return countsByLabel.entrySet().stream()
                 .sorted(Comparator
-                        .comparingInt(entry -> ageOrderKey(entry.getKey()))
+                        .comparingInt((Map.Entry<String, TrendCounter> entry) ->
+                                ageOrderKey(entry.getKey()))
                         .thenComparing(Map.Entry::getKey))
                 .map(entry -> new QuoteStatistics.TrendPoint(entry.getKey(),
                         entry.getValue().getTotal(), entry.getValue().getFailed()))


### PR DESCRIPTION
## Summary
- Ensure the default source data lookup honours the configured working directory when resolving inputs
- Restore an HtmlReportGenerator overload that infers the date range when one is not supplied explicitly
- Make CSV separator directive skipping resilient to parsed rows with trailing delimiter cells
- Fix QuoteStatisticsCalculator trend comparators so they compile with explicit generic types

## Testing
- `mvn -o -Dtest=QuoteReportGeneratorInputResolutionTest test` *(fails: missing org.apache.maven.plugins:maven-resources-plugin 3.3.1 in offline environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d4d0de4f4c8325a6ccd4987f1d536f