### PR TITLE
Add comprehensive top rejected models table

### DIFF
--- a/src/main/java/com/example/motorreporting/HtmlReportGenerator.java
+++ b/src/main/java/com/example/motorreporting/HtmlReportGenerator.java
@@ -537,6 +537,8 @@ public class HtmlReportGenerator {
         appendOutcomeTable(html, "Comprehensive Specification Outcomes (GCC vs Non-GCC)", compSpecificationSummary);
         appendMakeModelTable(html, "Top 20 Make & Model by Unique Chassis (Comprehensive)",
                 statistics.getComprehensiveTopRequestedMakeModelsByUniqueChassis());
+        appendMakeModelTable(html, "Top 20 Rejected Models (Unique Chassis)",
+                statistics.getComprehensiveTopRejectedModelsByUniqueChassis());
         html.append("    <div class=\"charts\">\n");
         html.append("      <div class=\"chart-card\">\n");
         html.append("        <h2>Success vs Failure Ratio by Age Range</h2>\n");

--- a/src/main/java/com/example/motorreporting/QuoteStatistics.java
+++ b/src/main/java/com/example/motorreporting/QuoteStatistics.java
@@ -46,6 +46,7 @@ public class QuoteStatistics {
     private final List<MakeModelChassisSummary> topRequestedMakeModelsByUniqueChassis;
     private final List<MakeModelChassisSummary> tplTopRequestedMakeModelsByUniqueChassis;
     private final List<MakeModelChassisSummary> comprehensiveTopRequestedMakeModelsByUniqueChassis;
+    private final List<MakeModelChassisSummary> comprehensiveTopRejectedModelsByUniqueChassis;
     private final Map<String, Long> tplErrorCounts;
     private final Map<String, Long> comprehensiveErrorCounts;
     private final List<CategoryCount> uniqueChassisBySpecification;
@@ -84,6 +85,7 @@ public class QuoteStatistics {
                            List<MakeModelChassisSummary> topRequestedMakeModelsByUniqueChassis,
                            List<MakeModelChassisSummary> tplTopRequestedMakeModelsByUniqueChassis,
                            List<MakeModelChassisSummary> comprehensiveTopRequestedMakeModelsByUniqueChassis,
+                           List<MakeModelChassisSummary> comprehensiveTopRejectedModelsByUniqueChassis,
                            Map<String, Long> tplErrorCounts,
                            Map<String, Long> comprehensiveErrorCounts,
                            List<CategoryCount> uniqueChassisBySpecification,
@@ -122,6 +124,8 @@ public class QuoteStatistics {
         this.tplTopRequestedMakeModelsByUniqueChassis = immutableCopy(tplTopRequestedMakeModelsByUniqueChassis);
         this.comprehensiveTopRequestedMakeModelsByUniqueChassis =
                 immutableCopy(comprehensiveTopRequestedMakeModelsByUniqueChassis);
+        this.comprehensiveTopRejectedModelsByUniqueChassis =
+                immutableCopy(comprehensiveTopRejectedModelsByUniqueChassis);
         this.tplErrorCounts = Collections.unmodifiableMap(new LinkedHashMap<>(tplErrorCounts));
         this.comprehensiveErrorCounts = Collections.unmodifiableMap(new LinkedHashMap<>(comprehensiveErrorCounts));
         this.uniqueChassisBySpecification = immutableCopy(uniqueChassisBySpecification);
@@ -233,6 +237,10 @@ public class QuoteStatistics {
 
     public List<MakeModelChassisSummary> getComprehensiveTopRequestedMakeModelsByUniqueChassis() {
         return comprehensiveTopRequestedMakeModelsByUniqueChassis;
+    }
+
+    public List<MakeModelChassisSummary> getComprehensiveTopRejectedModelsByUniqueChassis() {
+        return comprehensiveTopRejectedModelsByUniqueChassis;
     }
 
     public Map<String, Long> getTplErrorCounts() {

--- a/src/test/java/com/example/motorreporting/QuoteStatisticsCalculatorStatusTest.java
+++ b/src/test/java/com/example/motorreporting/QuoteStatisticsCalculatorStatusTest.java
@@ -184,6 +184,24 @@ class QuoteStatisticsCalculatorStatusTest {
         assertEquals(1, compToyota.getUniqueChassisCount());
         assertEquals(0, compToyota.getSuccessfulUniqueChassisCount());
         assertEquals(1, compToyota.getFailedUniqueChassisCount());
+
+        List<QuoteStatistics.MakeModelChassisSummary> compRejected =
+                statistics.getComprehensiveTopRejectedModelsByUniqueChassis();
+        assertEquals(2, compRejected.size());
+
+        QuoteStatistics.MakeModelChassisSummary rejectedHonda = compRejected.get(0);
+        assertEquals("Honda", rejectedHonda.getMake());
+        assertEquals("Civic", rejectedHonda.getModel());
+        assertEquals(2, rejectedHonda.getUniqueChassisCount());
+        assertEquals(1, rejectedHonda.getSuccessfulUniqueChassisCount());
+        assertEquals(1, rejectedHonda.getFailedUniqueChassisCount());
+
+        QuoteStatistics.MakeModelChassisSummary rejectedToyota = compRejected.get(1);
+        assertEquals("Toyota", rejectedToyota.getMake());
+        assertEquals("Corolla", rejectedToyota.getModel());
+        assertEquals(1, rejectedToyota.getUniqueChassisCount());
+        assertEquals(0, rejectedToyota.getSuccessfulUniqueChassisCount());
+        assertEquals(1, rejectedToyota.getFailedUniqueChassisCount());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- compute and expose the top 20 comprehensive make/model combinations by rejected unique chassis, including success and failure ratios
- render the new "Top 20 Rejected Models" table within the comprehensive analysis section
- extend unit coverage to validate the comprehensive rejected model summaries

## Testing
- `mvn test` *(fails: unable to download org.apache.maven.plugins:maven-resources-plugin:3.3.1 because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68d4ed869a248325934e4286b4e7918a