### PR TITLE
Add TPL nationality and fuel success ratio charts

### DIFF
--- a/src/main/java/com/example/motorreporting/HtmlReportGenerator.java
+++ b/src/main/java/com/example/motorreporting/HtmlReportGenerator.java
@@ -482,6 +482,23 @@ public class HtmlReportGenerator {
         appendMakeModelTable(html, "Top 20 Make & Model by Unique Chassis (TPL)",
                 statistics.getTplTopRequestedMakeModelsByUniqueChassis());
         html.append("    <div class=\"charts\">\n");
+        html.append("      <h2 class=\"section-title\">Success Ratios by Nationality & Fuel Type</h2>\n");
+        html.append("      <div class=\"chart-grid\">\n");
+        html.append("        <div class=\"chart-card\">\n");
+        html.append("          <h2>Chinese vs Non-Chinese</h2>\n");
+        html.append("          <canvas id=\"tplChineseOutcomeChart\"></canvas>\n");
+        html.append("        </div>\n");
+        html.append("        <div class=\"chart-card\">\n");
+        html.append("          <h2>Electric vs Non-Electric</h2>\n");
+        html.append("          <canvas id=\"tplElectricOutcomeChart\"></canvas>\n");
+        html.append("        </div>\n");
+        html.append("        <div class=\"chart-card chart-card--wide\">\n");
+        html.append("          <h2>Chinese & Fuel Type Segments</h2>\n");
+        html.append("          <canvas id=\"tplChineseElectricSegmentChart\"></canvas>\n");
+        html.append("        </div>\n");
+        html.append("      </div>\n");
+        html.append("    </div>\n");
+        html.append("    <div class=\"charts\">\n");
         html.append("      <div class=\"chart-card\">\n");
         html.append("        <h2>Success vs Failure Ratio by Age Range</h2>\n");
         html.append("        <canvas id=\"tplAgeRatioChart\"></canvas>\n");
@@ -1067,6 +1084,10 @@ public class HtmlReportGenerator {
         long compUniqueFailureCount = compUniqueRequests.getFailureCount();
 
         Map<String, QuoteStatistics.OutcomeBreakdown> tplBodyOutcomes = statistics.getTplBodyCategoryOutcomes();
+        Map<String, QuoteStatistics.OutcomeBreakdown> tplChineseOutcomes = statistics.getTplChineseOutcomeBreakdown();
+        Map<String, QuoteStatistics.OutcomeBreakdown> tplElectricOutcomes = statistics.getTplElectricOutcomeBreakdown();
+        Map<String, QuoteStatistics.OutcomeBreakdown> tplChineseElectricOutcomes =
+                statistics.getTplChineseElectricOutcomeBreakdown();
         Map<String, QuoteStatistics.OutcomeBreakdown> compBodyOutcomes = statistics.getComprehensiveBodyCategoryOutcomes();
         List<QuoteStatistics.AgeRangeStats> tplAgeStats = statistics.getTplAgeRangeStats();
         List<QuoteStatistics.AgeRangeStats> compAgeStats = statistics.getComprehensiveAgeRangeStats();
@@ -1140,6 +1161,22 @@ public class HtmlReportGenerator {
                 compBodyFailureValues.add(breakdown.getFailureCount());
             }
         }
+
+        List<String> tplChineseLabels = new ArrayList<>();
+        List<Double> tplChineseSuccessRatios = new ArrayList<>();
+        List<Double> tplChineseFailureRatios = new ArrayList<>();
+        populateOutcomeRatioData(tplChineseOutcomes, tplChineseLabels, tplChineseSuccessRatios, tplChineseFailureRatios);
+
+        List<String> tplElectricLabels = new ArrayList<>();
+        List<Double> tplElectricSuccessRatios = new ArrayList<>();
+        List<Double> tplElectricFailureRatios = new ArrayList<>();
+        populateOutcomeRatioData(tplElectricOutcomes, tplElectricLabels, tplElectricSuccessRatios, tplElectricFailureRatios);
+
+        List<String> tplChineseElectricLabels = new ArrayList<>();
+        List<Double> tplChineseElectricSuccessRatios = new ArrayList<>();
+        List<Double> tplChineseElectricFailureRatios = new ArrayList<>();
+        populateOutcomeRatioData(tplChineseElectricOutcomes, tplChineseElectricLabels,
+                tplChineseElectricSuccessRatios, tplChineseElectricFailureRatios);
 
         List<String> tplAgeLabels = new ArrayList<>();
         List<Double> tplAgeSuccessRatios = new ArrayList<>();
@@ -1299,6 +1336,18 @@ public class HtmlReportGenerator {
         script.append("    interaction: { mode: 'index', intersect: false },\n");
         script.append("    scales: { y: { beginAtZero: true, max: 100, ticks: { callback: value => `${value}%` } } },\n");
         script.append("    plugins: { tooltip: { callbacks: { label: ctx => `${ctx.dataset.label}: ${ctx.raw.toFixed(1)}%` } } }\n");
+        script.append("  };\n");
+        script.append("  const stackedRatioOptions = {\n");
+        script.append("    responsive: true,\n");
+        script.append("    interaction: { mode: 'index', intersect: false },\n");
+        script.append("    scales: {\n");
+        script.append("      x: { stacked: true },\n");
+        script.append("      y: { beginAtZero: true, max: 100, stacked: true, ticks: { callback: value => `${value}%` } }\n");
+        script.append("    },\n");
+        script.append("    plugins: {\n");
+        script.append("      legend: { display: true, position: 'bottom', labels: { usePointStyle: true } },\n");
+        script.append("      tooltip: { callbacks: { label: ctx => `${ctx.dataset.label}: ${ctx.raw.toFixed(1)}%` } }\n");
+        script.append("    }\n");
         script.append("  };\n");
         script.append("  const trendLineOptions = {\n");
         script.append("    responsive: true,\n");
@@ -1631,6 +1680,63 @@ public class HtmlReportGenerator {
         script.append("      }\n");
         script.append("    ]\n");
         script.append("  };\n");
+        script.append("  const tplChineseOutcomeData = {\n");
+        script.append("    labels: ").append(toJsStringArray(tplChineseLabels)).append(",\n");
+        script.append("    datasets: [\n");
+        script.append("      {\n");
+        script.append("        label: 'Success %',\n");
+        script.append("        data: ").append(toJsDoubleArray(tplChineseSuccessRatios)).append(",\n");
+        script.append("        backgroundColor: 'rgba(22, 163, 74, 0.85)',\n");
+        script.append("        stack: 'ratio',\n");
+        script.append("        borderRadius: 8\n");
+        script.append("      },\n");
+        script.append("      {\n");
+        script.append("        label: 'Failure %',\n");
+        script.append("        data: ").append(toJsDoubleArray(tplChineseFailureRatios)).append(",\n");
+        script.append("        backgroundColor: 'rgba(220, 38, 38, 0.8)',\n");
+        script.append("        stack: 'ratio',\n");
+        script.append("        borderRadius: 8\n");
+        script.append("      }\n");
+        script.append("    ]\n");
+        script.append("  };\n");
+        script.append("  const tplElectricOutcomeData = {\n");
+        script.append("    labels: ").append(toJsStringArray(tplElectricLabels)).append(",\n");
+        script.append("    datasets: [\n");
+        script.append("      {\n");
+        script.append("        label: 'Success %',\n");
+        script.append("        data: ").append(toJsDoubleArray(tplElectricSuccessRatios)).append(",\n");
+        script.append("        backgroundColor: 'rgba(14, 116, 144, 0.85)',\n");
+        script.append("        stack: 'ratio',\n");
+        script.append("        borderRadius: 8\n");
+        script.append("      },\n");
+        script.append("      {\n");
+        script.append("        label: 'Failure %',\n");
+        script.append("        data: ").append(toJsDoubleArray(tplElectricFailureRatios)).append(",\n");
+        script.append("        backgroundColor: 'rgba(234, 179, 8, 0.85)',\n");
+        script.append("        stack: 'ratio',\n");
+        script.append("        borderRadius: 8\n");
+        script.append("      }\n");
+        script.append("    ]\n");
+        script.append("  };\n");
+        script.append("  const tplChineseElectricSegmentData = {\n");
+        script.append("    labels: ").append(toJsStringArray(tplChineseElectricLabels)).append(",\n");
+        script.append("    datasets: [\n");
+        script.append("      {\n");
+        script.append("        label: 'Success %',\n");
+        script.append("        data: ").append(toJsDoubleArray(tplChineseElectricSuccessRatios)).append(",\n");
+        script.append("        backgroundColor: 'rgba(59, 130, 246, 0.85)',\n");
+        script.append("        stack: 'ratio',\n");
+        script.append("        borderRadius: 8\n");
+        script.append("      },\n");
+        script.append("      {\n");
+        script.append("        label: 'Failure %',\n");
+        script.append("        data: ").append(toJsDoubleArray(tplChineseElectricFailureRatios)).append(",\n");
+        script.append("        backgroundColor: 'rgba(217, 70, 239, 0.8)',\n");
+        script.append("        stack: 'ratio',\n");
+        script.append("        borderRadius: 8\n");
+        script.append("      }\n");
+        script.append("    ]\n");
+        script.append("  };\n");
         script.append("  const tplAgeRatioData = {\n");
         script.append("    labels: ").append(toJsStringArray(tplAgeLabels)).append(",\n");
         script.append("    datasets: [\n");
@@ -1706,6 +1812,9 @@ public class HtmlReportGenerator {
         script.append("  registerConversionToggle('tplSalesAge', tplSalesAgeChart);\n");
         script.append("  registerConversionToggle('compSalesBody', compSalesBodyChart);\n");
         script.append("  registerConversionToggle('compSalesAge', compSalesAgeChart);\n");
+        script.append("  new Chart(document.getElementById('tplChineseOutcomeChart'), { type: 'bar', data: tplChineseOutcomeData, options: stackedRatioOptions });\n");
+        script.append("  new Chart(document.getElementById('tplElectricOutcomeChart'), { type: 'bar', data: tplElectricOutcomeData, options: stackedRatioOptions });\n");
+        script.append("  new Chart(document.getElementById('tplChineseElectricSegmentChart'), { type: 'bar', data: tplChineseElectricSegmentData, options: stackedRatioOptions });\n");
         script.append("  new Chart(document.getElementById('tplOutcomesChart'), { type: 'bar', data: tplData, options: sharedOptions });\n");
         script.append("  new Chart(document.getElementById('compOutcomesChart'), { type: 'bar', data: compData, options: sharedOptions });\n");
         script.append("  new Chart(document.getElementById('overallSpecUniqueChart'), { type: 'bar', data: overallSpecificationData, options: sharedOptions });\n");
@@ -1776,6 +1885,27 @@ public class HtmlReportGenerator {
         script.append("  });\n");
         script.append("</script>\n");
         return script.toString();
+    }
+
+    private void populateOutcomeRatioData(Map<String, QuoteStatistics.OutcomeBreakdown> outcomes,
+                                          List<String> labels,
+                                          List<Double> successRatios,
+                                          List<Double> failureRatios) {
+        if (outcomes.isEmpty()) {
+            labels.add("No Data");
+            successRatios.add(0.0);
+            failureRatios.add(0.0);
+            return;
+        }
+        for (Map.Entry<String, QuoteStatistics.OutcomeBreakdown> entry : outcomes.entrySet()) {
+            QuoteStatistics.OutcomeBreakdown breakdown = entry.getValue();
+            long total = breakdown.getProcessedTotal();
+            double successRatio = total == 0 ? 0.0 : (breakdown.getSuccessCount() * 100.0) / total;
+            double failureRatio = total == 0 ? 0.0 : (breakdown.getFailureCount() * 100.0) / total;
+            labels.add(entry.getKey());
+            successRatios.add(successRatio);
+            failureRatios.add(failureRatio);
+        }
     }
 
     private void populateSalesChartData(List<QuoteStatistics.SalesConversionStats> stats,

--- a/src/main/java/com/example/motorreporting/QuoteRecord.java
+++ b/src/main/java/com/example/motorreporting/QuoteRecord.java
@@ -564,6 +564,53 @@ public class QuoteRecord {
         return Optional.of(errorText.trim());
     }
 
+    public boolean isChineseQuote() {
+        String value = getValueIgnoreCase(rawValues, "IsChinese");
+        if (value == null) {
+            return false;
+        }
+        String normalized = value.trim();
+        if (normalized.isEmpty()) {
+            return false;
+        }
+        if ("1".equals(normalized)) {
+            return true;
+        }
+        String lowerCase = normalized.toLowerCase(Locale.ROOT);
+        return "true".equals(lowerCase) || "yes".equals(lowerCase);
+    }
+
+    public boolean isElectricVehicle() {
+        String value = getValueIgnoreCase(rawValues, "FuelType");
+        if (value == null) {
+            return false;
+        }
+        return "ELECTRIC POWER".equalsIgnoreCase(value.trim());
+    }
+
+    public String getChineseClassificationLabel() {
+        return isChineseQuote() ? "Chinese Quotes" : "Non-Chinese Quotes";
+    }
+
+    public String getElectricClassificationLabel() {
+        return isElectricVehicle() ? "Electric Vehicles" : "Non-Electric Vehicles";
+    }
+
+    public String getChineseElectricSegmentLabel() {
+        boolean chinese = isChineseQuote();
+        boolean electric = isElectricVehicle();
+        if (chinese && electric) {
+            return "Chinese · Electric";
+        }
+        if (chinese) {
+            return "Chinese · Non-Electric";
+        }
+        if (electric) {
+            return "Non-Chinese · Electric";
+        }
+        return "Non-Chinese · Non-Electric";
+    }
+
     private static String labelOrUnknown(String value) {
         if (value == null || value.isEmpty()) {
             return "Unknown";

--- a/src/main/java/com/example/motorreporting/QuoteStatistics.java
+++ b/src/main/java/com/example/motorreporting/QuoteStatistics.java
@@ -31,6 +31,9 @@ public class QuoteStatistics {
     private final long comprehensiveUniqueChassisFailCount;
     private final Map<String, OutcomeBreakdown> tplBodyCategoryOutcomes;
     private final Map<String, OutcomeBreakdown> tplSpecificationOutcomes;
+    private final Map<String, OutcomeBreakdown> tplChineseOutcomes;
+    private final Map<String, OutcomeBreakdown> tplElectricOutcomes;
+    private final Map<String, OutcomeBreakdown> tplChineseElectricOutcomes;
     private final Map<String, OutcomeBreakdown> comprehensiveBodyCategoryOutcomes;
     private final Map<String, OutcomeBreakdown> comprehensiveSpecificationOutcomes;
     private final List<AgeRangeStats> tplAgeRangeStats;
@@ -70,6 +73,9 @@ public class QuoteStatistics {
                            long comprehensiveUniqueChassisFailCount,
                            Map<String, OutcomeBreakdown> tplBodyCategoryOutcomes,
                            Map<String, OutcomeBreakdown> tplSpecificationOutcomes,
+                           Map<String, OutcomeBreakdown> tplChineseOutcomes,
+                           Map<String, OutcomeBreakdown> tplElectricOutcomes,
+                           Map<String, OutcomeBreakdown> tplChineseElectricOutcomes,
                            Map<String, OutcomeBreakdown> comprehensiveBodyCategoryOutcomes,
                            Map<String, OutcomeBreakdown> comprehensiveSpecificationOutcomes,
                            List<AgeRangeStats> tplAgeRangeStats,
@@ -108,6 +114,9 @@ public class QuoteStatistics {
         this.comprehensiveUniqueChassisFailCount = comprehensiveUniqueChassisFailCount;
         this.tplBodyCategoryOutcomes = Collections.unmodifiableMap(new LinkedHashMap<>(tplBodyCategoryOutcomes));
         this.tplSpecificationOutcomes = Collections.unmodifiableMap(new LinkedHashMap<>(tplSpecificationOutcomes));
+        this.tplChineseOutcomes = Collections.unmodifiableMap(new LinkedHashMap<>(tplChineseOutcomes));
+        this.tplElectricOutcomes = Collections.unmodifiableMap(new LinkedHashMap<>(tplElectricOutcomes));
+        this.tplChineseElectricOutcomes = Collections.unmodifiableMap(new LinkedHashMap<>(tplChineseElectricOutcomes));
         this.comprehensiveBodyCategoryOutcomes = Collections.unmodifiableMap(new LinkedHashMap<>(comprehensiveBodyCategoryOutcomes));
         this.comprehensiveSpecificationOutcomes = Collections.unmodifiableMap(new LinkedHashMap<>(comprehensiveSpecificationOutcomes));
         this.tplAgeRangeStats = immutableCopy(tplAgeRangeStats);
@@ -217,6 +226,18 @@ public class QuoteStatistics {
 
     public Map<String, OutcomeBreakdown> getTplSpecificationOutcomes() {
         return tplSpecificationOutcomes;
+    }
+
+    public Map<String, OutcomeBreakdown> getTplChineseOutcomeBreakdown() {
+        return tplChineseOutcomes;
+    }
+
+    public Map<String, OutcomeBreakdown> getTplElectricOutcomeBreakdown() {
+        return tplElectricOutcomes;
+    }
+
+    public Map<String, OutcomeBreakdown> getTplChineseElectricOutcomeBreakdown() {
+        return tplChineseElectricOutcomes;
     }
 
     public List<AgeRangeStats> getTplAgeRangeStats() {

--- a/src/main/java/com/example/motorreporting/QuoteStatisticsCalculator.java
+++ b/src/main/java/com/example/motorreporting/QuoteStatisticsCalculator.java
@@ -98,6 +98,12 @@ public final class QuoteStatisticsCalculator {
                 computeOutcomeBreakdown(tplRecords, QuoteRecord::getBodyCategoryLabel);
         Map<String, QuoteStatistics.OutcomeBreakdown> tplSpecificationOutcomes =
                 computeOutcomeBreakdown(tplRecords, QuoteRecord::getOverrideSpecificationLabel);
+        Map<String, QuoteStatistics.OutcomeBreakdown> tplChineseOutcomes =
+                computeOutcomeBreakdown(tplRecords, QuoteRecord::getChineseClassificationLabel);
+        Map<String, QuoteStatistics.OutcomeBreakdown> tplElectricOutcomes =
+                computeOutcomeBreakdown(tplRecords, QuoteRecord::getElectricClassificationLabel);
+        Map<String, QuoteStatistics.OutcomeBreakdown> tplChineseElectricOutcomes =
+                computeOutcomeBreakdown(tplRecords, QuoteRecord::getChineseElectricSegmentLabel);
         Map<String, QuoteStatistics.OutcomeBreakdown> compBodyCategoryOutcomes =
                 computeOutcomeBreakdown(compRecords, QuoteRecord::getBodyCategoryLabel);
         Map<String, QuoteStatistics.OutcomeBreakdown> compSpecificationOutcomes =
@@ -154,6 +160,9 @@ public final class QuoteStatisticsCalculator {
                 compUniqueChassisSummary.getFailureCount(),
                 tplBodyCategoryOutcomes,
                 tplSpecificationOutcomes,
+                tplChineseOutcomes,
+                tplElectricOutcomes,
+                tplChineseElectricOutcomes,
                 compBodyCategoryOutcomes,
                 compSpecificationOutcomes,
                 tplAgeRangeStats,


### PR DESCRIPTION
## Summary
- add three new Chart.js canvases in the TPL section for Chinese, electric, and combined Chinese-electric success ratios
- compute the required outcome breakdowns in the statistics pipeline and expose them to the HTML generator
- extend quote parsing with helpers to classify Chinese and electric quotes

## Testing
- `mvn -q test` *(fails: plugin download blocked by network restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_68d4f00f2728832582d9661a9c482244