### PR TITLE
Fix QuoteRecord constructor invocation order

### DIFF
--- a/src/main/java/com/example/motorreporting/QuoteRecord.java
+++ b/src/main/java/com/example/motorreporting/QuoteRecord.java
@@ -123,8 +123,8 @@ public class QuoteRecord {
         LocalDateTime quoteRequestedOn = parseQuoteRequestedOn(getValueIgnoreCase(normalized, "QuoteRequestedOn"));
 
         return new QuoteRecord(normalized, insuranceType, status, insurancePurpose, insuranceCompanyName, errorText,
-                manufactureYear, estimatedValue, quoteNumber, policyNumber, chassisNumber, eid, outcome, bodyCategory, overrideSpec,
-                driverAge, model, make, quoteRequestedOn, policyPremium);
+                manufactureYear, estimatedValue, quoteNumber, policyNumber, chassisNumber, policyPremium, eid, outcome,
+                bodyCategory, overrideSpec, driverAge, model, make, quoteRequestedOn);
     }
 
     private static String getValueIgnoreCase(Map<String, String> values, String key) {


### PR DESCRIPTION
## Summary
- fix the QuoteRecord factory to pass arguments in the order expected by the constructor so compilation succeeds

## Testing
- `mvn test` *(fails: unable to download org.apache.maven.plugins:maven-resources-plugin due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_68d5077296d48325822099c634717ff5