### PR TITLE
Fix missing comprehensive summary variables in HTML generator

### DIFF
--- a/src/main/java/com/example/motorreporting/HtmlReportGenerator.java
+++ b/src/main/java/com/example/motorreporting/HtmlReportGenerator.java
@@ -92,6 +92,15 @@ public class HtmlReportGenerator {
         String headerText = buildHeaderText(records, reportDateRange);
         Optional<String> insuranceCompanyName = findInsuranceCompanyName(records);
 
+        long compPoliciesSold = statistics.getComprehensivePoliciesSold();
+        BigDecimal compTotalPremium = statistics.getComprehensiveTotalPremium();
+        double compChineseSalesRatio = statistics.getComprehensiveChineseSalesRatio();
+        double compElectricSalesRatio = statistics.getComprehensiveElectricSalesRatio();
+        List<QuoteStatistics.SalesPremiumBreakdown> compBodyPremiumBreakdowns =
+                statistics.getComprehensiveBodyTypePremiums();
+        List<QuoteStatistics.MakeModelPremiumSummary> compTopModelsByPremium =
+                statistics.getComprehensiveTopModelsByPremium();
+
         StringBuilder html = new StringBuilder();
         html.append("<!DOCTYPE html>\n");
         html.append("<html lang=\"en\">\n");


### PR DESCRIPTION
## Summary
- initialize comprehensive summary metrics before building the HTML so the template can reference them

## Testing
- `mvn -q test` *(fails: network is unreachable while downloading maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_b_68d50bab885c83258ee031bb68c6e5c8