### PR TITLE
Add TPL sales metrics and premium breakdown visuals

### DIFF
--- a/src/main/java/com/example/motorreporting/QuoteStatistics.java
+++ b/src/main/java/com/example/motorreporting/QuoteStatistics.java
@@ -45,6 +45,12 @@ public class QuoteStatistics {
     private final List<SalesConversionStats> tplSalesByAgeRange;
     private final List<SalesConversionStats> tplSalesByChineseClassification;
     private final List<SalesConversionStats> tplSalesByFuelType;
+    private final long tplPoliciesSold;
+    private final BigDecimal tplTotalPremium;
+    private final List<SalesPremiumBreakdown> tplBodyTypePremiums;
+    private final List<MakeModelPremiumSummary> tplTopModelsByPremium;
+    private final double tplChineseSalesRatio;
+    private final double tplElectricSalesRatio;
     private final List<SalesConversionStats> comprehensiveSalesByBodyType;
     private final List<SalesConversionStats> comprehensiveSalesByAgeRange;
     private final List<SalesConversionStats> comprehensiveSalesByChineseClassification;
@@ -97,6 +103,12 @@ public class QuoteStatistics {
                            List<SalesConversionStats> tplSalesByAgeRange,
                            List<SalesConversionStats> tplSalesByChineseClassification,
                            List<SalesConversionStats> tplSalesByFuelType,
+                           long tplPoliciesSold,
+                           BigDecimal tplTotalPremium,
+                           List<SalesPremiumBreakdown> tplBodyTypePremiums,
+                           List<MakeModelPremiumSummary> tplTopModelsByPremium,
+                           double tplChineseSalesRatio,
+                           double tplElectricSalesRatio,
                            List<SalesConversionStats> comprehensiveSalesByBodyType,
                            List<SalesConversionStats> comprehensiveSalesByAgeRange,
                            List<SalesConversionStats> comprehensiveSalesByChineseClassification,
@@ -148,6 +160,13 @@ public class QuoteStatistics {
         this.tplSalesByAgeRange = immutableCopy(tplSalesByAgeRange);
         this.tplSalesByChineseClassification = immutableCopy(tplSalesByChineseClassification);
         this.tplSalesByFuelType = immutableCopy(tplSalesByFuelType);
+        this.tplPoliciesSold = tplPoliciesSold;
+        BigDecimal safeTplTotalPremium = tplTotalPremium == null ? BigDecimal.ZERO : tplTotalPremium;
+        this.tplTotalPremium = safeTplTotalPremium.setScale(2, RoundingMode.HALF_UP);
+        this.tplBodyTypePremiums = immutableCopy(tplBodyTypePremiums);
+        this.tplTopModelsByPremium = immutableCopy(tplTopModelsByPremium);
+        this.tplChineseSalesRatio = tplChineseSalesRatio;
+        this.tplElectricSalesRatio = tplElectricSalesRatio;
         this.comprehensiveSalesByBodyType = immutableCopy(comprehensiveSalesByBodyType);
         this.comprehensiveSalesByAgeRange = immutableCopy(comprehensiveSalesByAgeRange);
         this.comprehensiveSalesByChineseClassification =
@@ -325,6 +344,30 @@ public class QuoteStatistics {
 
     public List<SalesConversionStats> getTplSalesByFuelType() {
         return tplSalesByFuelType;
+    }
+
+    public long getTplPoliciesSold() {
+        return tplPoliciesSold;
+    }
+
+    public BigDecimal getTplTotalPremium() {
+        return tplTotalPremium;
+    }
+
+    public List<SalesPremiumBreakdown> getTplBodyTypePremiums() {
+        return tplBodyTypePremiums;
+    }
+
+    public List<MakeModelPremiumSummary> getTplTopModelsByPremium() {
+        return tplTopModelsByPremium;
+    }
+
+    public double getTplChineseSalesRatio() {
+        return tplChineseSalesRatio;
+    }
+
+    public double getTplElectricSalesRatio() {
+        return tplElectricSalesRatio;
     }
 
     public List<SalesConversionStats> getComprehensiveSalesByBodyType() {

--- a/src/main/java/com/example/motorreporting/QuoteStatisticsCalculator.java
+++ b/src/main/java/com/example/motorreporting/QuoteStatisticsCalculator.java
@@ -128,6 +128,16 @@ public final class QuoteStatisticsCalculator {
                 computeSalesConversionByClassifier(tplRecords, QuoteRecord::getChineseClassificationLabel);
         List<QuoteStatistics.SalesConversionStats> tplSalesByFuelType =
                 computeSalesConversionByClassifier(tplRecords, QuoteRecord::getElectricClassificationLabel);
+        List<QuoteStatistics.SalesPremiumBreakdown> tplBodyPremiumBreakdowns =
+                computePremiumBreakdownByBodyType(tplRecords);
+        BigDecimal tplTotalPremium = tplBodyPremiumBreakdowns.stream()
+                .map(QuoteStatistics.SalesPremiumBreakdown::getTotalPremium)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        long tplPoliciesSold = tplBodyPremiumBreakdowns.stream()
+                .mapToLong(QuoteStatistics.SalesPremiumBreakdown::getSoldPolicies)
+                .sum();
+        List<QuoteStatistics.MakeModelPremiumSummary> tplTopModelsByPremium =
+                computeTopModelsByPremium(tplRecords, TOP_PREMIUM_MODEL_LIMIT);
         List<QuoteStatistics.SalesConversionStats> compSalesByBodyType =
                 computeSalesConversionByBodyType(compRecords);
         List<QuoteStatistics.SalesConversionStats> compSalesByAgeRange =
@@ -146,6 +156,8 @@ public final class QuoteStatisticsCalculator {
                 .sum();
         List<QuoteStatistics.MakeModelPremiumSummary> compTopModelsByPremium =
                 computeTopModelsByPremium(compRecords, TOP_PREMIUM_MODEL_LIMIT);
+        double tplChineseSalesRatio = findConversionRatio(tplSalesByChineseClassification, CHINESE_LABEL);
+        double tplElectricSalesRatio = findConversionRatio(tplSalesByFuelType, ELECTRIC_LABEL);
         double compChineseSalesRatio = findConversionRatio(compSalesByChineseClassification, CHINESE_LABEL);
         double compElectricSalesRatio = findConversionRatio(compSalesByFuelType, ELECTRIC_LABEL);
         Map<String, Long> tplErrorCounts = computeErrorCounts(tplRecords, false);
@@ -198,6 +210,12 @@ public final class QuoteStatisticsCalculator {
                 tplSalesByAgeRange,
                 tplSalesByChineseClassification,
                 tplSalesByFuelType,
+                tplPoliciesSold,
+                tplTotalPremium,
+                tplBodyPremiumBreakdowns,
+                tplTopModelsByPremium,
+                tplChineseSalesRatio,
+                tplElectricSalesRatio,
                 compSalesByBodyType,
                 compSalesByAgeRange,
                 compSalesByChineseClassification,


### PR DESCRIPTION
## Summary
- add TPL policy and premium summary cards, body type tables, and premium mix chart to the sales page
- extend HTML helpers to support generic empty states and expose new TPL premium data in the report scripts
- track TPL premium totals, model rankings, and conversion ratios when building quote statistics

## Testing
- mvn -q -DskipTests package *(fails: Network is unreachable while resolving Maven plugins)*

------
https://chatgpt.com/codex/tasks/task_b_68d50d76823883259fc83beaf8db5d6f