### PR TITLE
Fix missing premium data initialization in HtmlReportGenerator

### DIFF
--- a/src/main/java/com/example/motorreporting/HtmlReportGenerator.java
+++ b/src/main/java/com/example/motorreporting/HtmlReportGenerator.java
@@ -1259,6 +1259,9 @@ public class HtmlReportGenerator {
         List<QuoteStatistics.MakeModelPremiumSummary> compTopModelsByPremium =
                 statistics.getComprehensiveTopModelsByPremium();
 
+        List<QuoteStatistics.SalesPremiumBreakdown> tplBodyPremiumBreakdowns =
+                statistics.getTplBodyTypePremiums();
+
         Map<String, QuoteStatistics.OutcomeBreakdown> tplBodyOutcomes = statistics.getTplBodyCategoryOutcomes();
         Map<String, QuoteStatistics.OutcomeBreakdown> tplChineseOutcomes = statistics.getTplChineseOutcomeBreakdown();
         Map<String, QuoteStatistics.OutcomeBreakdown> tplElectricOutcomes = statistics.getTplElectricOutcomeBreakdown();


### PR DESCRIPTION
## Summary
- initialize the TPL body premium breakdown list inside HtmlReportGenerator.buildScripts so script generation can populate its charts

## Testing
- mvn -q test *(fails: unable to download maven-resources-plugin because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68d50ff33f48832599604b0a33947878