### PR TITLE
Fix missing sales by body data in HTML report

### DIFF
--- a/src/main/java/com/example/motorreporting/HtmlReportGenerator.java
+++ b/src/main/java/com/example/motorreporting/HtmlReportGenerator.java
@@ -100,6 +100,8 @@ public class HtmlReportGenerator {
                 statistics.getTplBodyTypePremiums();
         List<QuoteStatistics.MakeModelPremiumSummary> tplTopModelsByPremium =
                 statistics.getTplTopModelsByPremium();
+        List<QuoteStatistics.SalesConversionStats> tplSalesByBody =
+                statistics.getTplSalesByBodyType();
         long compPoliciesSold = statistics.getComprehensivePoliciesSold();
         BigDecimal compTotalPremium = statistics.getComprehensiveTotalPremium();
         double compChineseSalesRatio = statistics.getComprehensiveChineseSalesRatio();
@@ -108,6 +110,8 @@ public class HtmlReportGenerator {
                 statistics.getComprehensiveBodyTypePremiums();
         List<QuoteStatistics.MakeModelPremiumSummary> compTopModelsByPremium =
                 statistics.getComprehensiveTopModelsByPremium();
+        List<QuoteStatistics.SalesConversionStats> compSalesByBody =
+                statistics.getComprehensiveSalesByBodyType();
 
         StringBuilder html = new StringBuilder();
         html.append("<!DOCTYPE html>\n");


### PR DESCRIPTION
## Summary
- retrieve TPL and Comprehensive sales-by-body statistics before they are rendered in the HTML summary tables

## Testing
- `mvn test` *(fails: unable to download org.apache.maven.plugins:maven-resources-plugin:3.3.1 due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_68d516c10af08325a8daf75c1eea9819